### PR TITLE
Fix HTTP CDN links — upgrade Bootstrap CSS and jQuery to HTTPS

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <html>
     <head>
         <title>reconcile test page</title>
-        <link href="http://netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css" rel="stylesheet">
+        <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
         <style>
             .match-same { background-color: #0f0; }
 
@@ -9,7 +9,7 @@
 
             .match-contains { background-color: #ffc; }
         </style>
-        <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js" type="text/javascript"></script>
+        <script src="https://code.jquery.com/jquery-1.9.1.min.js" type="text/javascript"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.js" type="text/javascript"></script>
         <script src="reconcileTestService.js" type="text/javascript"></script>
         <script src="reconcileBootstrapView.js" type="text/javascript"></script>

--- a/index.test.js
+++ b/index.test.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('index.html', () => {
+    let html;
+
+    beforeAll(() => {
+        html = fs.readFileSync(path.join(__dirname, 'index.html'), 'utf8');
+    });
+
+    it('loads all external resources over HTTPS, not HTTP', () => {
+        const httpUrls = html.match(/(?:src|href)="http:\/\/[^"]+"/g) || [];
+        expect(httpUrls).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary

- Bootstrap CSS was loaded over plain `http://netdna.bootstrapcdn.com` — a defunct CDN and an active MITM injection risk.
- jQuery was also loaded over plain `http://ajax.googleapis.com`.
- Both are now HTTPS. Bootstrap CSS moved to `cdnjs.cloudflare.com` at 3.3.7 (matching the Bootstrap JS already on the page). jQuery moved to `code.jquery.com`.
- Fixes #3.

## Changes

- `index.html` — both HTTP CDN URLs replaced with HTTPS equivalents; Bootstrap CSS version aligned to 3.3.7
- `index.test.js` — new Jest test asserting no `src`/`href` attributes use `http://`

## Test plan

- [x] `npm test` passes (1/1 tests green)
- [x] Test was confirmed RED against the unfixed file (caught both Bootstrap CSS and jQuery)
- [x] Preview panel shows the page loading correctly with updated CDN links

🤖 Generated with [Claude Code](https://claude.com/claude-code)