### PR TITLE
Extract weight constants — eliminate magic numbers between controller and view

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
                 reconcile.setService(reconcileTestService);
                 reconcileBootstrapView.setMasterDiv($('.reconcile'));
                 reconcileBootstrapView.setShowList(true);
+                reconcileBootstrapView.setWeights(reconcile.WEIGHTS);
                 reconcile.setView(reconcileBootstrapView);
                 reconcile.init();
             });

--- a/reconcile.js
+++ b/reconcile.js
@@ -83,12 +83,14 @@
         return result.filter(function(item) { return item.weights['matchTotal'] > 0; }).sort(sortByMatchTotal);
     };
 
+    var WEIGHTS = { EXACT: 100, WHITESPACE: 80, CONTAINS: 30 };
+
     var getWeight = function(cell1, cell2) {
         if (cell1 == null) return 0;
         if (cell2 == null) return 0;
-        if (cell1 == cell2) return 100;
-        if (isSameWs(cell1, cell2)) return 80;
-        if (doesContain(cell1, cell2)) return 30;
+        if (cell1 == cell2) return WEIGHTS.EXACT;
+        if (isSameWs(cell1, cell2)) return WEIGHTS.WHITESPACE;
+        if (doesContain(cell1, cell2)) return WEIGHTS.CONTAINS;
         return 0;
     };
 
@@ -135,6 +137,7 @@
         init: init,
         setService: setService,
         setView: setView,
-        setIdProperty: setIdProperty
+        setIdProperty: setIdProperty,
+        WEIGHTS: WEIGHTS
     };
 }));

--- a/reconcile.test.js
+++ b/reconcile.test.js
@@ -33,6 +33,16 @@ describe('reconcile', () => {
         reconcile.init();
     });
 
+    describe('WEIGHTS', () => {
+        it('exports named weight constants used by the scoring algorithm', () => {
+            expect(reconcile.WEIGHTS).toEqual({
+                EXACT: 100,
+                WHITESPACE: 80,
+                CONTAINS: 30
+            });
+        });
+    });
+
     describe('undo()', () => {
         it('calls service.undo() with the IDs of the last matched pair', () => {
             reconcile.match({ a: '5', b: 'A' });

--- a/reconcileBootstrapView.js
+++ b/reconcileBootstrapView.js
@@ -10,6 +10,9 @@
     var masterDiv = null;
     var showList = false;
     var idProperty = 'id';
+    var weights = { EXACT: 100, WHITESPACE: 80, CONTAINS: 30 };
+
+    var setWeights = function(w) { weights = w; };
 
     var setMasterDiv = function(div) { masterDiv = div; };
     var setShowList = function(showList1) { showList = showList1; };
@@ -52,9 +55,9 @@
             for (var key in item) {
                 if (key != idProperty && key != 'weights') {
                     var cellDiv = $('<div class="col-md-1">' + item[key] + '</div>');
-                    if (item.weights[key] == 100) cellDiv.addClass('match-same');
-                    if (item.weights[key] == 80) cellDiv.addClass('match-samews');
-                    if (item.weights[key] == 30) cellDiv.addClass('match-contains');
+                    if (item.weights[key] == weights.EXACT) cellDiv.addClass('match-same');
+                    if (item.weights[key] == weights.WHITESPACE) cellDiv.addClass('match-samews');
+                    if (item.weights[key] == weights.CONTAINS) cellDiv.addClass('match-contains');
                     candidateDiv.append(cellDiv);
                 }
             }
@@ -131,6 +134,7 @@
         setMasterDiv: setMasterDiv,
         setShowList: setShowList,
         setIdProperty: setIdProperty,
+        setWeights: setWeights,
         addEvent: addEvent,
         next: next,
         prev: prev,

--- a/reconcileBootstrapView.test.js
+++ b/reconcileBootstrapView.test.js
@@ -1,0 +1,9 @@
+const view = require('./reconcileBootstrapView');
+
+describe('reconcileBootstrapView', () => {
+    describe('setWeights()', () => {
+        it('is exported as a function', () => {
+            expect(typeof view.setWeights).toBe('function');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- `100`/`80`/`30` were hardcoded independently in both `reconcile.js` and `reconcileBootstrapView.js`. A change to one silently broke CSS highlighting in the other.
- Fixes #4.
- `reconcile.js` now defines `WEIGHTS = { EXACT: 100, WHITESPACE: 80, CONTAINS: 30 }`, uses the named constants internally, and exposes them on its public API.
- `reconcileBootstrapView.js` gains a `setWeights(w)` function; `buildCandidates` references `weights.EXACT` etc. instead of bare numbers.
- `index.html` calls `reconcileBootstrapView.setWeights(reconcile.WEIGHTS)` at startup to wire them together.

## Changes

- `reconcile.js` — define `WEIGHTS`, use in `getWeight()`, expose on return object
- `reconcileBootstrapView.js` — add `weights` variable with default values, `setWeights()` setter, use named keys in `buildCandidates`
- `index.html` — add `setWeights(reconcile.WEIGHTS)` call before `setView`
- `reconcile.test.js` — new `WEIGHTS` describe block asserting the exported shape
- `reconcileBootstrapView.test.js` — new test file asserting `setWeights` is exported

## Test plan

- [x] `npm test` — 7/7 tests green
- [x] New tests were confirmed RED before the fix
- [x] Preview panel shows page rendering correctly with colour highlighting intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)