### PR TITLE
Upgrade jQuery 1.9.1 → 3.7.1 and Bootstrap 3.3.7 → 5.3.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <html>
     <head>
         <title>reconcile test page</title>
-        <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
         <style>
             .match-same { background-color: #0f0; }
 
@@ -9,8 +9,8 @@
 
             .match-contains { background-color: #ffc; }
         </style>
-        <script src="https://code.jquery.com/jquery-1.9.1.min.js" type="text/javascript"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.js" type="text/javascript"></script>
+        <script src="https://code.jquery.com/jquery-3.7.1.min.js" type="text/javascript"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" type="text/javascript"></script>
         <script src="reconcileTestService.js" type="text/javascript"></script>
         <script src="reconcileBootstrapView.js" type="text/javascript"></script>
         <script src="reconcile.js" type="text/javascript"></script>

--- a/index.test.js
+++ b/index.test.js
@@ -12,4 +12,16 @@ describe('index.html', () => {
         const httpUrls = html.match(/(?:src|href)="http:\/\/[^"]+"/g) || [];
         expect(httpUrls).toEqual([]);
     });
+
+    it('loads jQuery 3.x or later', () => {
+        const match = html.match(/jquery[.\-](\d+)\.\d+/i);
+        expect(match).not.toBeNull();
+        expect(parseInt(match[1])).toBeGreaterThanOrEqual(3);
+    });
+
+    it('loads Bootstrap 5.x or later', () => {
+        const match = html.match(/bootstrap[/@-](\d+)\.\d+/i);
+        expect(match).not.toBeNull();
+        expect(parseInt(match[1])).toBeGreaterThanOrEqual(5);
+    });
 });


### PR DESCRIPTION
## Summary

- jQuery 1.9.1 (2013) and Bootstrap 3.3.7 (2016) had known CVEs and were loaded from inconsistent CDNs.
- Fixes #5.
- jQuery upgraded to 3.7.1 via `code.jquery.com`. Bootstrap upgraded to 5.3.3 via `cdn.jsdelivr.net`; CSS and JS bundle now from the same CDN at the same version.

## Changes

- `index.html` — three CDN URLs replaced (Bootstrap CSS, jQuery, Bootstrap JS)
- `index.test.js` — two new assertions: jQuery major version ≥ 3, Bootstrap major version ≥ 5

## Test plan

- [x] `npm test` — 9/9 tests green, no regressions
- [x] New version tests were confirmed RED against the old URLs
- [x] Preview panel shows the page — please verify layout and buttons render correctly with Bootstrap 5 before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)