### PR TITLE
Fix undo() position — navigate to restored item (closes #6)

### DIFF
--- a/reconcile.js
+++ b/reconcile.js
@@ -126,6 +126,7 @@
         service.undo(lastMatch.a[idProperty], lastMatch.b[idProperty]);
         listA.push(lastMatch.a);
         listB.push(lastMatch.b);
+        position = listA.length - 1;
         redraw();
     };
 

--- a/reconcile.test.js
+++ b/reconcile.test.js
@@ -54,5 +54,47 @@ describe('reconcile', () => {
             reconcile.undo();
             expect(service.undo).not.toHaveBeenCalled();
         });
+
+        describe('position after undo', () => {
+            beforeEach(() => {
+                jest.resetModules();
+                reconcile = require('./reconcile');
+
+                service = {
+                    load: jest.fn().mockReturnValue(resolvedPromise({
+                        a: [
+                            { id: '5', firstName: 'Nick',  lastName: 'Sarkosy' },
+                            { id: '6', firstName: 'Alice', lastName: 'Smith'   }
+                        ],
+                        b: [{ id: 'A', firstName: 'Nicholas', lastName: 'Zarkosi' }]
+                    })),
+                    set: jest.fn(),
+                    undo: jest.fn()
+                };
+
+                view = {
+                    load: jest.fn(),
+                    showError: jest.fn(),
+                    addEvent: jest.fn(),
+                    setIdProperty: jest.fn()
+                };
+
+                reconcile.setService(service);
+                reconcile.setView(view);
+                reconcile.init();
+            });
+
+            it('navigates to the restored item after undo', () => {
+                // match the first item; listA now has only id '6' at position 0
+                reconcile.match({ a: '5', b: 'A' });
+                view.load.mockClear();
+
+                reconcile.undo();
+
+                // restored item (id '5') should be the one displayed
+                const displayedItem = view.load.mock.calls[0][0];
+                expect(displayedItem.id).toBe('5');
+            });
+        });
     });
 });


### PR DESCRIPTION
## Summary
- `undo()` now sets `position = listA.length - 1` before redrawing, so the user immediately sees the just-restored item rather than staying on the previously-viewed item
- Added a test with a two-item `listA` that catches the regression: after matching one item then undoing, `view.load` must be called with the restored item

## Test plan
- [ ] `npm test` — all 10 tests pass, no regressions
- [ ] Manual: match an item, press Undo — confirm the view jumps to the un-matched item

🤖 Generated with [Claude Code](https://claude.com/claude-code)