### PR TITLE
Replace alert() with console.log() in test service (closes #9)

### DIFF
--- a/reconcileTestService.js
+++ b/reconcileTestService.js
@@ -44,12 +44,12 @@
     };
 
     var set = function (listAId, listBId) {
-        alert('matching ' + listAId + ' => ' + listBId);
+        console.log('matching ' + listAId + ' => ' + listBId);
         /* let systems know of match */
         // $.postJSON('/api/matches',{sysa:listAId,sysb:listBId});
     };
     var undo = function (listAId, listBId) {
-        alert('undoing ' + listAId + ' => ' + listBId);
+        console.log('undoing ' + listAId + ' => ' + listBId);
         /* let systems know that this match is bogus */
         /*
         $.ajax({

--- a/reconcileTestService.test.js
+++ b/reconcileTestService.test.js
@@ -1,6 +1,22 @@
 const service = require('./reconcileTestService');
 
 describe('reconcileTestService', () => {
+    describe('set()', () => {
+        it('does not call alert()', () => {
+            global.alert = jest.fn();
+            service.set('1', 'A');
+            expect(global.alert).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('undo()', () => {
+        it('does not call alert()', () => {
+            global.alert = jest.fn();
+            service.undo('1', 'A');
+            expect(global.alert).not.toHaveBeenCalled();
+        });
+    });
+
     describe('dateOfBirth formatting in standardised list A', () => {
         let listA;
 


### PR DESCRIPTION
## Summary
- Replaced `alert()` with `console.log()` in `reconcileTestService.js` `set()` and `undo()`
- Two tests added confirming neither function calls `alert()`

## Test plan
- [ ] `npm test` — all 21 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)