### PR TITLE
Fix duplicate accesskey="m" on Match buttons (closes #11)

### DIFF
--- a/__mocks__/jquery.js
+++ b/__mocks__/jquery.js
@@ -1,5 +1,21 @@
-// Minimal synchronous jQuery stub for Jest — covers Deferred/promise and $.when.
-const $ = function() {};
+// Minimal synchronous jQuery stub for Jest — covers Deferred/promise, $.when, $.each,
+// and chainable DOM-building stubs. $ is a jest.fn() so tests can inspect $.mock.calls.
+const makeEl = () => {
+    const el = {
+        empty: () => el,
+        append: () => el,
+        addClass: () => el,
+        on: () => el,
+        find: () => el,
+        prop: () => el,
+        focus: () => el,
+        first: () => el,
+        attr: () => '',
+    };
+    return el;
+};
+
+const $ = jest.fn(() => makeEl());
 
 $.Deferred = function() {
     let _value;
@@ -21,6 +37,10 @@ $.when = function(promise) {
             if (success) success(_resolved);
         }
     };
+};
+
+$.each = function(arr, fn) {
+    arr.forEach(function(item, i) { fn(i, item); });
 };
 
 module.exports = $;

--- a/reconcileBootstrapView.js
+++ b/reconcileBootstrapView.js
@@ -50,7 +50,7 @@
     };
 
     var buildCandidates = function(matchItem, candidates) {
-        var result = candidates.map(function(item) {
+        var result = candidates.map(function(item, index) {
             var candidateDiv = $('<div class="row">');
             Object.keys(item).forEach(function(key) {
                 if (key != idProperty && key != 'weights') {
@@ -61,7 +61,7 @@
                     candidateDiv.append(cellDiv);
                 }
             });
-            var matchButton = $('<button class="btn" accesskey="m" data-a="' + matchItem[idProperty] + '" data-b="' + item[idProperty] + '">Match</button>');
+            var matchButton = $('<button class="btn"' + (index === 0 ? ' accesskey="m"' : '') + ' data-a="' + matchItem[idProperty] + '" data-b="' + item[idProperty] + '">Match</button>');
             $(matchButton).on('click', match);
             var newDiv = $('<div class="col-md-1">');
             newDiv.append(matchButton);

--- a/reconcileBootstrapView.test.js
+++ b/reconcileBootstrapView.test.js
@@ -6,4 +6,63 @@ describe('reconcileBootstrapView', () => {
             expect(typeof view.setWeights).toBe('function');
         });
     });
+
+    describe('buildCandidates (via load)', () => {
+        let $, localView;
+
+        beforeEach(() => {
+            jest.resetModules();
+            $ = require('jquery');
+            localView = require('./reconcileBootstrapView');
+            localView.setMasterDiv($('<div>'));
+            localView.setWeights({ EXACT: 100, WHITESPACE: 80, CONTAINS: 30 });
+        });
+
+        function matchButtonHtmls() {
+            return $.mock.calls
+                .map(function(args) { return args[0]; })
+                .filter(function(s) { return typeof s === 'string' && /^<button[^>]*>Match<\/button>$/.test(s); });
+        }
+
+        it('assigns accesskey="m" to the first candidate button', () => {
+            const matchItem = { id: '0', name: 'Alice' };
+            const candidates = [
+                { id: '1', name: 'Alice', weights: { name: 100, matchTotal: 100 } },
+                { id: '2', name: 'Bob',   weights: { name: 30,  matchTotal: 30  } },
+            ];
+
+            localView.load(matchItem, candidates, [matchItem], [], []);
+
+            const buttons = matchButtonHtmls();
+            expect(buttons.length).toBeGreaterThanOrEqual(1);
+            expect(buttons[0]).toContain('accesskey="m"');
+        });
+
+        it('does not assign accesskey="m" to subsequent candidate buttons', () => {
+            const matchItem = { id: '0', name: 'Alice' };
+            const candidates = [
+                { id: '1', name: 'Alice', weights: { name: 100, matchTotal: 100 } },
+                { id: '2', name: 'Bob',   weights: { name: 30,  matchTotal: 30  } },
+            ];
+
+            localView.load(matchItem, candidates, [matchItem], [], []);
+
+            const buttons = matchButtonHtmls();
+            expect(buttons.length).toBe(2);
+            expect(buttons[1]).not.toContain('accesskey="m"');
+        });
+
+        it('assigns accesskey="m" when there is exactly one candidate', () => {
+            const matchItem = { id: '0', name: 'Alice' };
+            const candidates = [
+                { id: '1', name: 'Alice', weights: { name: 100, matchTotal: 100 } },
+            ];
+
+            localView.load(matchItem, candidates, [matchItem], [], []);
+
+            const buttons = matchButtonHtmls();
+            expect(buttons.length).toBe(1);
+            expect(buttons[0]).toContain('accesskey="m"');
+        });
+    });
 });


### PR DESCRIPTION
## Summary

- `buildCandidates` was assigning `accesskey="m"` to every Match button, giving browsers undefined behaviour when multiple candidates were shown
- Fixed by passing the `map` index into the callback and only adding `accesskey="m"` when `index === 0`
- Upgraded `__mocks__/jquery.js` to a `jest.fn()`-based chainable stub with `$.each` support so view behaviour can be unit-tested

## Test plan

- [ ] `npm test` — all 28 tests pass (3 new tests in `reconcileBootstrapView.test.js` covering first-button accesskey, no-accesskey on subsequent buttons, and single-candidate case)
- [ ] Manual: render multiple candidates and confirm only the top-ranked button responds to the `m` accesskey

🤖 Generated with [Claude Code](https://claude.com/claude-code)