### PR TITLE
Migrate to TypeScript classes with constructor injection (closes #29)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,5 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run lint
+      - run: npx tsc --noEmit
       - run: npm run build

--- a/index.html
+++ b/index.html
@@ -11,23 +11,11 @@
         </style>
         <script src="https://code.jquery.com/jquery-3.7.1.min.js" type="text/javascript"></script>
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" type="text/javascript"></script>
-        <script src="reconcileTestService.js" type="text/javascript"></script>
-        <script src="reconcileBootstrapView.js" type="text/javascript"></script>
-        <script src="reconcile.js" type="text/javascript"></script>
-        <script>
-            $(document).ready(function() {
-                reconcile.setService(reconcileTestService);
-                reconcileBootstrapView.setMasterDiv($('.reconcile'));
-                reconcileBootstrapView.setShowList(true);
-                reconcileBootstrapView.setWeights(reconcile.WEIGHTS);
-                reconcile.setView(reconcileBootstrapView);
-                reconcile.init();
-            });
-        </script>
     </head>
     <body>
         <div style="border: 1pt solid black; margin: 30px;">
             <div class="reconcile container"></div>
         </div>
+        <script type="module" src="/src/main.ts"></script>
     </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,14 @@
       "name": "reconcile",
       "version": "1.0.0",
       "devDependencies": {
+        "@types/jquery": "^4.0.0",
+        "@types/node": "^25.6.0",
         "bootstrap": "^5.3.3",
         "eslint": "^9.25.1",
         "jest": "^29.7.0",
         "jquery": "^3.7.1",
+        "ts-jest": "^29.4.9",
+        "typescript": "^6.0.3",
         "vite": "^8.0.10"
       }
     },
@@ -1594,6 +1598,13 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jquery": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-4.0.0.tgz",
+      "integrity": "sha512-Z+to+A2VkaHq1DfI2oSwsoCdhCHMpTSgjWzNcbNlRGYzksDBpPUgEcAL+RQjOBJRaLoEAOHXxqDGBVP+BblBwg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1953,6 +1964,19 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -2815,6 +2839,28 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -4137,6 +4183,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4182,6 +4235,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -4237,6 +4297,16 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4267,6 +4337,13 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5024,6 +5101,85 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/ts-jest": {
+      "version": "29.4.9",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
+      "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.9",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.4",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <7"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -5066,6 +5222,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/undici-types": {
@@ -5257,6 +5441,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -11,15 +11,22 @@
     "lint": "eslint ."
   },
   "devDependencies": {
+    "@types/jquery": "^4.0.0",
+    "@types/node": "^25.6.0",
     "bootstrap": "^5.3.3",
     "eslint": "^9.25.1",
     "jest": "^29.7.0",
     "jquery": "^3.7.1",
+    "ts-jest": "^29.4.9",
+    "typescript": "^6.0.3",
     "vite": "^8.0.10"
   },
   "jest": {
     "moduleNameMapper": {
       "^jquery$": "<rootDir>/__mocks__/jquery.js"
+    },
+    "transform": {
+      "^.+\\.tsx?$": ["ts-jest", { "tsconfig": "tsconfig.test.json" }]
     }
   }
 }

--- a/reconcile.test.js
+++ b/reconcile.test.js
@@ -1,36 +1,32 @@
-function resolvedPromise(value) {
-    return {
-        done: function(cb) { cb(value); return this; },
-        then: function(cb) { cb(value); return this; }
-    };
-}
+const { Reconciler } = require('./src/reconciler');
 
-describe('reconcile', () => {
+describe('Reconciler', () => {
     let reconcile, service, view;
 
-    beforeEach(() => {
-        jest.resetModules();
-        reconcile = require('./reconcile');
-
-        service = {
-            load: jest.fn().mockReturnValue(resolvedPromise({
-                a: [{ id: '5', firstName: 'Nick', lastName: 'Sarkosy' }],
-                b: [{ id: 'A', firstName: 'Nicholas', lastName: 'Zarkosi' }]
-            })),
+    function makeService(a, b) {
+        return {
+            load: jest.fn().mockResolvedValue({ a, b }),
             set: jest.fn(),
-            undo: jest.fn()
+            undo: jest.fn(),
         };
+    }
 
-        view = {
+    function makeView() {
+        return {
             load: jest.fn(),
             showError: jest.fn(),
-            addEvent: jest.fn(),
-            setIdProperty: jest.fn()
+            onAction: jest.fn(),
         };
+    }
 
-        reconcile.setService(service);
-        reconcile.setView(view);
-        reconcile.init();
+    beforeEach(async () => {
+        service = makeService(
+            [{ id: '5', firstName: 'Nick', lastName: 'Sarkosy' }],
+            [{ id: 'A', firstName: 'Nicholas', lastName: 'Zarkosi' }]
+        );
+        view = makeView();
+        reconcile = new Reconciler(service, view);
+        await reconcile.init();
     });
 
     describe('WEIGHTS', () => {
@@ -44,82 +40,76 @@ describe('reconcile', () => {
     });
 
     describe('getCandidates()', () => {
-        let r, v;
-
-        function setup(a, b) {
-            jest.resetModules();
-            r = require('./reconcile');
-            v = { load: jest.fn(), showError: jest.fn(), addEvent: jest.fn(), setIdProperty: jest.fn() };
-            const svc = { load: jest.fn().mockReturnValue(resolvedPromise({ a, b })), set: jest.fn(), undo: jest.fn() };
-            r.setService(svc);
-            r.setView(v);
-            r.init();
+        async function setup(a, b) {
+            const svc = makeService(a, b);
+            const v = makeView();
+            const r = new Reconciler(svc, v);
+            await r.init();
+            return { r, v };
         }
 
-        function candidates() { return v.load.mock.calls[0][1]; }
+        function candidates(v) { return v.load.mock.calls[0][1]; }
 
-        it('scores an exact field match at 100', () => {
-            setup(
+        it('scores an exact field match at 100', async () => {
+            const { v } = await setup(
                 [{ id: '1', name: 'Alice' }],
                 [{ id: 'X', name: 'Alice' }]
             );
-            expect(candidates()[0].weights.name).toBe(100);
+            expect(candidates(v)[0].weights.name).toBe(100);
         });
 
-        it('scores a whitespace-normalised match at 80', () => {
-            setup(
+        it('scores a whitespace-normalised match at 80', async () => {
+            const { v } = await setup(
                 [{ id: '1', name: 'John Smith' }],
                 [{ id: 'X', name: 'JohnSmith' }]
             );
-            expect(candidates()[0].weights.name).toBe(80);
+            expect(candidates(v)[0].weights.name).toBe(80);
         });
 
-        it('scores a substring/contains match at 30', () => {
-            setup(
+        it('scores a substring/contains match at 30', async () => {
+            const { v } = await setup(
                 [{ id: '1', name: 'Anders' }],
                 [{ id: 'X', name: 'Anderson' }]
             );
-            expect(candidates()[0].weights.name).toBe(30);
+            expect(candidates(v)[0].weights.name).toBe(30);
         });
 
-        it('excludes items with no matching fields from candidates', () => {
-            setup(
+        it('excludes items with no matching fields from candidates', async () => {
+            const { v } = await setup(
                 [{ id: '1', name: 'Alice' }],
                 [{ id: 'X', name: 'Bob' }, { id: 'Y', name: 'Alice' }]
             );
-            expect(candidates().map(c => c.id)).toEqual(['Y']);
+            expect(candidates(v).map(c => c.id)).toEqual(['Y']);
         });
 
-        it('sorts candidates by matchTotal descending', () => {
-            setup(
+        it('sorts candidates by matchTotal descending', async () => {
+            const { v } = await setup(
                 [{ id: '1', name: 'Alice', city: 'Paris' }],
                 [
                     { id: 'X', name: 'Alice', city: 'London' },
                     { id: 'Y', name: 'Alice', city: 'Paris'  }
                 ]
             );
-            // Y matches on both name and city (200), X only on name (100)
-            expect(candidates().map(c => c.id)).toEqual(['Y', 'X']);
+            expect(candidates(v).map(c => c.id)).toEqual(['Y', 'X']);
         });
 
-        it('excludes candidates whose matchable fields are all null', () => {
-            setup(
+        it('excludes candidates whose matchable fields are all null', async () => {
+            const { v } = await setup(
                 [{ id: '1', name: 'Alice' }],
                 [{ id: 'X', name: null }]
             );
-            expect(candidates()).toEqual([]);
+            expect(candidates(v)).toEqual([]);
         });
 
-        it('does not score inherited enumerable properties', () => {
+        it('does not score inherited enumerable properties', async () => {
             const proto = { name: 'Alice' };
             const inherited = Object.create(proto);
             inherited.id = 'X';
-            // inherited has no own 'name' — only via prototype
-            setup(
+            const { v } = await setup(
                 [{ id: '1', name: 'Alice' }],
                 [inherited]
             );
-            expect(candidates()).toEqual([]);
+            expect(candidates(v)).toEqual([]);
         });
     });
 
@@ -153,42 +143,25 @@ describe('reconcile', () => {
         });
 
         describe('position after undo', () => {
-            beforeEach(() => {
-                jest.resetModules();
-                reconcile = require('./reconcile');
-
-                service = {
-                    load: jest.fn().mockReturnValue(resolvedPromise({
-                        a: [
-                            { id: '5', firstName: 'Nick',  lastName: 'Sarkosy' },
-                            { id: '6', firstName: 'Alice', lastName: 'Smith'   }
-                        ],
-                        b: [{ id: 'A', firstName: 'Nicholas', lastName: 'Zarkosi' }]
-                    })),
-                    set: jest.fn(),
-                    undo: jest.fn()
-                };
-
-                view = {
-                    load: jest.fn(),
-                    showError: jest.fn(),
-                    addEvent: jest.fn(),
-                    setIdProperty: jest.fn()
-                };
-
-                reconcile.setService(service);
-                reconcile.setView(view);
-                reconcile.init();
+            beforeEach(async () => {
+                service = makeService(
+                    [
+                        { id: '5', firstName: 'Nick',  lastName: 'Sarkosy' },
+                        { id: '6', firstName: 'Alice', lastName: 'Smith'   }
+                    ],
+                    [{ id: 'A', firstName: 'Nicholas', lastName: 'Zarkosi' }]
+                );
+                view = makeView();
+                reconcile = new Reconciler(service, view);
+                await reconcile.init();
             });
 
             it('navigates to the restored item after undo', () => {
-                // match the first item; listA now has only id '6' at position 0
                 reconcile.match({ a: '5', b: 'A' });
                 view.load.mockClear();
 
                 reconcile.undo();
 
-                // restored item (id '5') should be the one displayed
                 const displayedItem = view.load.mock.calls[0][0];
                 expect(displayedItem.id).toBe('5');
             });

--- a/reconcileBootstrapView.test.js
+++ b/reconcileBootstrapView.test.js
@@ -1,9 +1,11 @@
-const view = require('./reconcileBootstrapView');
-
-describe('reconcileBootstrapView', () => {
-    describe('setWeights()', () => {
-        it('is exported as a function', () => {
-            expect(typeof view.setWeights).toBe('function');
+describe('BootstrapView', () => {
+    describe('constructor', () => {
+        it('can be constructed with a container element and weights', () => {
+            jest.resetModules();
+            const $ = require('jquery');
+            const { BootstrapView } = require('./src/bootstrapView');
+            const view = new BootstrapView($('<div>'), { EXACT: 100, WHITESPACE: 80, CONTAINS: 30 });
+            expect(view).toBeDefined();
         });
     });
 
@@ -13,9 +15,8 @@ describe('reconcileBootstrapView', () => {
         beforeEach(() => {
             jest.resetModules();
             $ = require('jquery');
-            localView = require('./reconcileBootstrapView');
-            localView.setMasterDiv($('<div>'));
-            localView.setWeights({ EXACT: 100, WHITESPACE: 80, CONTAINS: 30 });
+            const { BootstrapView } = require('./src/bootstrapView');
+            localView = new BootstrapView($('<div>'), { EXACT: 100, WHITESPACE: 80, CONTAINS: 30 });
         });
 
         function matchButtonHtmls() {

--- a/reconcileTestService.test.js
+++ b/reconcileTestService.test.js
@@ -1,6 +1,12 @@
-const service = require('./reconcileTestService');
+const { SampleDataService } = require('./src/sampleDataService');
 
-describe('reconcileTestService', () => {
+describe('SampleDataService', () => {
+    let service;
+
+    beforeEach(() => {
+        service = new SampleDataService();
+    });
+
     describe('set()', () => {
         it('does not call alert()', () => {
             global.alert = jest.fn();
@@ -20,13 +26,13 @@ describe('reconcileTestService', () => {
     describe('dateOfBirth formatting in standardised list A', () => {
         let listA;
 
-        beforeEach(() => {
-            service.load().done(function(data) { listA = data.a; });
+        beforeEach(async () => {
+            const data = await service.load();
+            listA = data.a;
         });
 
         it('formats July as month 07, not 06', () => {
             // Nick: new Date(1966, 6, 6) = 6 July 1966 — getMonth() returns 6 (0-indexed)
-            // without +1 the month would be '06' (June) instead of '07' (July)
             const nick = listA.find(item => item.firstName === 'Nick');
             expect(nick.dateOfBirth).toBe('19660706');
         });

--- a/src/bootstrapView.ts
+++ b/src/bootstrapView.ts
@@ -1,0 +1,98 @@
+import $ from 'jquery';
+import { IView, Item, Candidate, Match, ActionType, ActionEvent } from './types';
+
+interface Weights {
+    EXACT: number;
+    WHITESPACE: number;
+    CONTAINS: number;
+}
+
+export class BootstrapView implements IView {
+    private readonly idProperty = 'id';
+    private readonly listeners: Partial<Record<ActionType, Array<(e: ActionEvent) => void>>> = {};
+
+    constructor(
+        private readonly masterDiv: JQuery,
+        private readonly weights: Weights,
+    ) {}
+
+    load(matchItem: Item, candidates: Candidate[], listA: Item[], listB: Item[], memento: Match[]): void {
+        this.masterDiv.empty();
+        if (listA.length > 0) {
+            this.masterDiv.append(this.buildMatchLine(matchItem, memento.length > 0));
+            this.masterDiv.append(this.buildHeaderDiv(matchItem));
+            this.buildCandidates(matchItem, candidates).forEach(el => this.masterDiv.append(el));
+            if (candidates.length === 1 || candidates[0].weights['matchTotal'] > candidates[1].weights['matchTotal']) {
+                $('button:contains("Match")').first().focus();
+            }
+        }
+    }
+
+    showError(status: unknown): void {
+        this.masterDiv.empty();
+        this.masterDiv.append($('<div>').text(String(status)));
+    }
+
+    onAction(type: ActionType, listener: (e: ActionEvent) => void): void {
+        if (!this.listeners[type]) this.listeners[type] = [];
+        this.listeners[type]!.push(listener);
+    }
+
+    private dispatch(e: ActionEvent): void {
+        (this.listeners[e.type] ?? []).forEach(fn => fn(e));
+    }
+
+    private next(): void  { this.dispatch({ type: 'next' }); }
+    private prev(): void  { this.dispatch({ type: 'prev' }); }
+    private undo(): void  { this.dispatch({ type: 'undo' }); }
+    private match(e: JQuery.ClickEvent): void {
+        this.dispatch({
+            type: 'match',
+            a: $(e.target).attr('data-a'),
+            b: $(e.target).attr('data-b'),
+        });
+    }
+
+    private buildMatchLine(matchItem: Item, canUndo: boolean): JQuery {
+        const row = $('<div class="row">');
+        Object.keys(matchItem).forEach(key => {
+            if (key !== this.idProperty) row.append($('<div class="col-md-1">' + matchItem[key] + '</div>'));
+        });
+        row.append($('<div class="col-md-1"><button class="btn" accesskey="n">Next</button></div>'));
+        row.append($('<div class="col-md-1"><button class="btn" accesskey="p">Prev</button></div>'));
+        row.append($('<div class="col-md-1"><button class="btn" accesskey="u">Undo</button></div>'));
+        $(row).find('button:contains("Next")').on('click', () => this.next());
+        $(row).find('button:contains("Prev")').on('click', () => this.prev());
+        $(row).find('button:contains("Undo")').on('click', () => this.undo());
+        if (!canUndo) $(row).find('button:contains("Undo")').prop('disabled', 'disabled');
+        return row;
+    }
+
+    private buildHeaderDiv(matchItem: Item): JQuery {
+        const header = $('<div class="row" style="background-color:#000;color:#fff">');
+        Object.keys(matchItem).forEach(key => {
+            if (key !== this.idProperty) header.append($('<div class="col-md-1">' + key + '</div>'));
+        });
+        return header;
+    }
+
+    private buildCandidates(matchItem: Item, candidates: Candidate[]): JQuery[] {
+        return candidates.map((item, index) => {
+            const row = $('<div class="row">');
+            Object.keys(item).forEach(key => {
+                if (key !== this.idProperty && key !== 'weights') {
+                    const cell = $('<div class="col-md-1">' + item[key] + '</div>');
+                    if (item.weights[key] === this.weights.EXACT)      cell.addClass('match-same');
+                    if (item.weights[key] === this.weights.WHITESPACE)  cell.addClass('match-samews');
+                    if (item.weights[key] === this.weights.CONTAINS)    cell.addClass('match-contains');
+                    row.append(cell);
+                }
+            });
+            const btn = $('<button class="btn"' + (index === 0 ? ' accesskey="m"' : '') +
+                ' data-a="' + matchItem[this.idProperty] + '" data-b="' + item[this.idProperty] + '">Match</button>');
+            $(btn).on('click', (e) => this.match(e));
+            row.append($('<div class="col-md-1">').append(btn));
+            return row;
+        });
+    }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,14 @@
+import { SampleDataService } from './sampleDataService';
+import { BootstrapView } from './bootstrapView';
+import { Reconciler } from './reconciler';
+
+const WEIGHTS = { EXACT: 100, WHITESPACE: 80, CONTAINS: 30 };
+
+const container = document.querySelector<HTMLElement>('.reconcile')!;
+import $ from 'jquery';
+
+const service = new SampleDataService();
+const view    = new BootstrapView($(container), WEIGHTS);
+const reconciler = new Reconciler(service, view);
+
+reconciler.init();

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -1,0 +1,113 @@
+import { IService, IView, Item, Candidate, Match, ActionEvent } from './types';
+
+const WEIGHTS = { EXACT: 100, WHITESPACE: 80, CONTAINS: 30 } as const;
+
+export class Reconciler {
+    readonly WEIGHTS = WEIGHTS;
+
+    private position = 0;
+    private listA: Item[] = [];
+    private listB: Item[] = [];
+    private readonly memento: Match[] = [];
+    private readonly idProperty = 'id';
+
+    constructor(private readonly service: IService, private readonly view: IView) {
+        view.onAction('next',  () => this.next());
+        view.onAction('prev',  () => this.prev());
+        view.onAction('undo',  () => this.undo());
+        view.onAction('match', (e) => this.match(e));
+    }
+
+    async init(): Promise<void> {
+        try {
+            const data = await this.service.load();
+            this.listA = data.a;
+            this.listB = data.b;
+            this.redraw();
+        } catch (status) {
+            this.view.showError(status);
+        }
+    }
+
+    next(): void {
+        this.position++;
+        if (this.position >= this.listA.length) this.position = 0;
+        this.redraw();
+    }
+
+    prev(): void {
+        this.position--;
+        if (this.position < 0) this.position = this.listA.length - 1;
+        this.redraw();
+    }
+
+    match(event: ActionEvent): void {
+        const { a: aId, b: bId } = event;
+        if (!aId || !bId) return;
+        this.service.set(aId, bId);
+        const lastMatch: Match = {
+            a: this.listA.find(item => item[this.idProperty] === aId)!,
+            b: this.listB.find(item => item[this.idProperty] === bId)!,
+        };
+        this.memento.push(lastMatch);
+        this.listA = this.listA.filter(item => item[this.idProperty] !== aId);
+        this.listB = this.listB.filter(item => item[this.idProperty] !== bId);
+        this.redraw();
+    }
+
+    undo(): void {
+        if (this.memento.length === 0) return;
+        const lastMatch = this.memento.pop()!;
+        this.service.undo(lastMatch.a[this.idProperty] as string, lastMatch.b[this.idProperty] as string);
+        this.listA.push(lastMatch.a);
+        this.listB.push(lastMatch.b);
+        this.position = this.listA.length - 1;
+        this.redraw();
+    }
+
+    private redraw(): void {
+        const matchItem = this.listA[this.position];
+        this.view.load(matchItem, this.getCandidates(matchItem, this.listB), this.listA, this.listB, this.memento);
+    }
+
+    private getCandidates(matchItem: Item, list: Item[]): Candidate[] {
+        if (matchItem == null) return [];
+        const result = list.map(item => {
+            const candidate: Record<string, unknown> = {};
+            const weights: Record<string, number> = {};
+            let matchTotal = 0;
+            Object.keys(item).forEach(key => {
+                candidate[key] = item[key];
+                if (key !== this.idProperty) {
+                    weights[key] = this.getWeight(item[key], matchItem[key]);
+                    matchTotal += weights[key];
+                }
+            });
+            weights['matchTotal'] = matchTotal;
+            candidate['weights'] = weights;
+            return candidate as Candidate;
+        });
+        return result
+            .filter(item => item.weights['matchTotal'] > 0)
+            .sort((a, b) => b.weights['matchTotal'] - a.weights['matchTotal']);
+    }
+
+    private getWeight(cell1: unknown, cell2: unknown): number {
+        if (cell1 == null) return 0;
+        if (cell2 == null) return 0;
+        if (cell1 === cell2) return WEIGHTS.EXACT;
+        if (this.isSameWs(cell1, cell2)) return WEIGHTS.WHITESPACE;
+        if (this.doesContain(cell1, cell2)) return WEIGHTS.CONTAINS;
+        return 0;
+    }
+
+    private isSameWs(cell1: unknown, cell2: unknown): boolean {
+        return String(cell1).toUpperCase().replace(/\s/g, '') === String(cell2).toUpperCase().replace(/\s/g, '');
+    }
+
+    private doesContain(cell1: unknown, cell2: unknown): boolean {
+        const s1 = String(cell1).toUpperCase();
+        const s2 = String(cell2).toUpperCase();
+        return s1.includes(s2) || s2.includes(s1);
+    }
+}

--- a/src/sampleDataService.ts
+++ b/src/sampleDataService.ts
@@ -1,0 +1,73 @@
+import { IService, Item } from './types';
+
+interface RawA {
+    FirstName: string;
+    LastName: string;
+    DL: string;
+    DOB: Date;
+    PKey: number;
+    SSN: string | null;
+}
+
+interface RawB {
+    id: string;
+    name: { last: string; first: string };
+    drivers: string;
+    dateOfBirth: string;
+}
+
+const RAW_LIST_A: RawA[] = [
+    { FirstName: 'Nick',   LastName: 'Sarkosy',   DL: '123456789', DOB: new Date(1966, 6, 6),  PKey: 5, SSN: null },
+    { FirstName: 'Dale',   LastName: 'Earnhardt',  DL: '123456780', DOB: new Date(1935, 1, 12), PKey: 4, SSN: '123456789' },
+    { FirstName: 'Oliver', LastName: 'Clark',      DL: '123456782', DOB: new Date(1966, 6, 6),  PKey: 3, SSN: '123456123' },
+];
+
+const RAW_LIST_B: RawB[] = [
+    { id: 'A', name: { last: 'Zarkosi',      first: 'Nicholas' }, drivers: '123456789', dateOfBirth: '19660606' },
+    { id: 'B', name: { last: 'Earnhardt Sr', first: 'Dale'     }, drivers: '123456780', dateOfBirth: '19350112' },
+    { id: 'C', name: { last: 'Earnhardt Jr', first: 'Dale'     }, drivers: '123456781', dateOfBirth: '19660606' },
+    { id: 'D', name: { last: 'Oliver',       first: 'Clark'    }, drivers: '123456782', dateOfBirth: '19660606' },
+];
+
+function makeAStandard(item: RawA): Item {
+    const dob = item.DOB;
+    const year  = dob.getFullYear().toString();
+    const month = ('0' + (dob.getMonth() + 1)).slice(-2);
+    const day   = ('0' + dob.getDate()).slice(-2);
+    return {
+        id:          item.PKey.toString(),
+        firstName:   item.FirstName,
+        lastName:    item.LastName,
+        gid:         item.DL,
+        dateOfBirth: year + month + day,
+        ssn:         item.SSN,
+    };
+}
+
+function makeBStandard(item: RawB): Item {
+    return {
+        id:          item.id,
+        firstName:   item.name.first,
+        lastName:    item.name.last,
+        gid:         item.drivers,
+        dateOfBirth: item.dateOfBirth,
+        ssn:         null,
+    };
+}
+
+export class SampleDataService implements IService {
+    async load(): Promise<{ a: Item[]; b: Item[] }> {
+        return {
+            a: RAW_LIST_A.map(makeAStandard),
+            b: RAW_LIST_B.map(makeBStandard),
+        };
+    }
+
+    set(aId: string, bId: string): void {
+        console.log(`matching ${aId} => ${bId}`);
+    }
+
+    undo(aId: string, bId: string): void {
+        console.log(`undoing ${aId} => ${bId}`);
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,33 @@
+export type ActionType = 'next' | 'prev' | 'undo' | 'match';
+
+export interface ActionEvent {
+    type: ActionType;
+    a?: string;
+    b?: string;
+}
+
+export interface Item {
+    id: string;
+    [key: string]: unknown;
+}
+
+export interface Candidate extends Item {
+    weights: Record<string, number>;
+}
+
+export interface Match {
+    a: Item;
+    b: Item;
+}
+
+export interface IService {
+    load(): Promise<{ a: Item[]; b: Item[] }>;
+    set(aId: string, bId: string): void;
+    undo(aId: string, bId: string): void;
+}
+
+export interface IView {
+    load(matchItem: Item, candidates: Candidate[], listA: Item[], listB: Item[], memento: Match[]): void;
+    showError(status: unknown): void;
+    onAction(type: ActionType, listener: (e: ActionEvent) => void): void;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "moduleResolution": "bundler",
     "strict": true,
     "allowJs": true,
+    "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "src/**/*"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `src/types.ts` with `IService`, `IView`, `Item`, `Candidate`, `Match`, `ActionEvent`, `ActionType`
- Converts `reconcileTestService.js` → `src/sampleDataService.ts` (`SampleDataService` class, native `async load()` replacing jQuery Deferred)
- Converts `reconcile.js` → `src/reconciler.ts` (`Reconciler` class, constructor injection of `IService`/`IView`, `async init()`)
- Converts `reconcileBootstrapView.js` → `src/bootstrapView.ts` (`BootstrapView` class implementing `IView`; `next`/`prev`/`undo`/`match` are internal)
- Adds `src/main.ts` as composition root — only file that knows concrete classes
- Updates `index.html` to use `<script type="module" src="/src/main.ts">` instead of the old inline script block
- Installs `typescript`, `ts-jest`, `@types/node`, `@types/jquery`; adds `tsconfig.test.json` (CommonJS module for Jest)
- Adds `npx tsc --noEmit` to CI

## Test plan

- [x] TDD: each class built test-first (SampleDataService tracer → Reconciler → BootstrapView)
- [x] `tsc --noEmit` exits 0
- [x] `npm run build` exits 0 — now bundles 9 modules cleanly (no more "can't be bundled" warnings from PR #33)
- [x] All 34 tests pass (28 original behaviors preserved in updated test files + 6 infrastructure tests from PR #33)
- [x] Old JS source files (`reconcile.js`, `reconcileBootstrapView.js`, `reconcileTestService.js`) are untouched — removed in a future PR once jQuery is gone

Part of the modernisation plan — PR 2 of 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)