### PR TITLE
Extract Scorer class (SRP + OCP) closes #30

### DIFF
--- a/reconcile.test.js
+++ b/reconcile.test.js
@@ -1,7 +1,10 @@
 const { Reconciler } = require('./src/reconciler');
+const { Scorer } = require('./src/scorer');
+
+const WEIGHTS = { EXACT: 100, WHITESPACE: 80, CONTAINS: 30 };
 
 describe('Reconciler', () => {
-    let reconcile, service, view;
+    let reconcile, service, view, scorer;
 
     function makeService(a, b) {
         return {
@@ -25,25 +28,16 @@ describe('Reconciler', () => {
             [{ id: 'A', firstName: 'Nicholas', lastName: 'Zarkosi' }]
         );
         view = makeView();
-        reconcile = new Reconciler(service, view);
+        scorer = new Scorer(WEIGHTS);
+        reconcile = new Reconciler(service, view, scorer);
         await reconcile.init();
     });
 
-    describe('WEIGHTS', () => {
-        it('exports named weight constants used by the scoring algorithm', () => {
-            expect(reconcile.WEIGHTS).toEqual({
-                EXACT: 100,
-                WHITESPACE: 80,
-                CONTAINS: 30
-            });
-        });
-    });
-
-    describe('getCandidates()', () => {
+    describe('getCandidates() — integration via view.load', () => {
         async function setup(a, b) {
             const svc = makeService(a, b);
             const v = makeView();
-            const r = new Reconciler(svc, v);
+            const r = new Reconciler(svc, v, new Scorer(WEIGHTS));
             await r.init();
             return { r, v };
         }
@@ -152,7 +146,7 @@ describe('Reconciler', () => {
                     [{ id: 'A', firstName: 'Nicholas', lastName: 'Zarkosi' }]
                 );
                 view = makeView();
-                reconcile = new Reconciler(service, view);
+                reconcile = new Reconciler(service, view, new Scorer(WEIGHTS));
                 await reconcile.init();
             });
 

--- a/scorer.test.js
+++ b/scorer.test.js
@@ -1,0 +1,104 @@
+const { Scorer } = require('./src/scorer');
+
+const WEIGHTS = { EXACT: 100, WHITESPACE: 80, CONTAINS: 30 };
+
+describe('Scorer', () => {
+    let scorer;
+    beforeEach(() => { scorer = new Scorer(WEIGHTS); });
+
+    describe('getWeight()', () => {
+        it('returns EXACT weight when values are identical', () => {
+            expect(scorer.getWeight('Alice', 'Alice')).toBe(100);
+        });
+
+        it('returns WHITESPACE weight when values match after stripping whitespace', () => {
+            expect(scorer.getWeight('John Smith', 'JohnSmith')).toBe(80);
+        });
+
+        it('returns CONTAINS weight when one value is a substring of the other', () => {
+            expect(scorer.getWeight('Anders', 'Anderson')).toBe(30);
+        });
+
+        it('returns 0 when first value is null', () => {
+            expect(scorer.getWeight(null, 'Alice')).toBe(0);
+        });
+
+        it('returns 0 when second value is null', () => {
+            expect(scorer.getWeight('Alice', null)).toBe(0);
+        });
+
+        it('returns 0 when values share no match', () => {
+            expect(scorer.getWeight('Alice', 'Bob')).toBe(0);
+        });
+    });
+
+    describe('isSameWs()', () => {
+        it('returns true when strings are equal after removing whitespace and uppercasing', () => {
+            expect(scorer.isSameWs('John Smith', 'JohnSmith')).toBe(true);
+        });
+
+        it('returns true when case differs', () => {
+            expect(scorer.isSameWs('john smith', 'JOHNSMITH')).toBe(true);
+        });
+
+        it('returns false when strings differ beyond whitespace', () => {
+            expect(scorer.isSameWs('Alice', 'Bob')).toBe(false);
+        });
+    });
+
+    describe('doesContain()', () => {
+        it('returns true when first value contains second', () => {
+            expect(scorer.doesContain('Anderson', 'Anders')).toBe(true);
+        });
+
+        it('returns true when second value contains first', () => {
+            expect(scorer.doesContain('Anders', 'Anderson')).toBe(true);
+        });
+
+        it('is case-insensitive', () => {
+            expect(scorer.doesContain('anderson', 'ANDERS')).toBe(true);
+        });
+
+        it('returns false when neither contains the other', () => {
+            expect(scorer.doesContain('Alice', 'Bob')).toBe(false);
+        });
+    });
+
+    describe('getCandidates()', () => {
+        it('returns a Candidate with per-field weights and a matchTotal', () => {
+            const matchItem = { id: '1', name: 'Alice' };
+            const list = [{ id: 'X', name: 'Alice' }];
+            const [c] = scorer.getCandidates(matchItem, list);
+            expect(c.weights.name).toBe(100);
+            expect(c.weights.matchTotal).toBe(100);
+        });
+
+        it('preserves original fields on the returned candidate', () => {
+            const matchItem = { id: '1', name: 'Alice' };
+            const list = [{ id: 'X', name: 'Alice' }];
+            const [c] = scorer.getCandidates(matchItem, list);
+            expect(c.id).toBe('X');
+            expect(c.name).toBe('Alice');
+        });
+
+        it('excludes items with zero matchTotal', () => {
+            const matchItem = { id: '1', name: 'Alice' };
+            const list = [{ id: 'X', name: 'Bob' }];
+            expect(scorer.getCandidates(matchItem, list)).toEqual([]);
+        });
+
+        it('sorts candidates by matchTotal descending', () => {
+            const matchItem = { id: '1', name: 'Alice', city: 'Paris' };
+            const list = [
+                { id: 'X', name: 'Alice', city: 'London' },
+                { id: 'Y', name: 'Alice', city: 'Paris'  },
+            ];
+            const ids = scorer.getCandidates(matchItem, list).map(c => c.id);
+            expect(ids).toEqual(['Y', 'X']);
+        });
+
+        it('returns empty array when matchItem is null', () => {
+            expect(scorer.getCandidates(null, [{ id: 'X', name: 'Alice' }])).toEqual([]);
+        });
+    });
+});

--- a/src/bootstrapView.ts
+++ b/src/bootstrapView.ts
@@ -1,11 +1,5 @@
 import $ from 'jquery';
-import { IView, Item, Candidate, Match, ActionType, ActionEvent } from './types';
-
-interface Weights {
-    EXACT: number;
-    WHITESPACE: number;
-    CONTAINS: number;
-}
+import { IView, Item, Candidate, Match, ActionType, ActionEvent, Weights } from './types';
 
 export class BootstrapView implements IView {
     private readonly idProperty = 'id';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,16 @@
 import { SampleDataService } from './sampleDataService';
 import { BootstrapView } from './bootstrapView';
 import { Reconciler } from './reconciler';
+import { Scorer } from './scorer';
+import $ from 'jquery';
 
 const WEIGHTS = { EXACT: 100, WHITESPACE: 80, CONTAINS: 30 };
 
 const container = document.querySelector<HTMLElement>('.reconcile')!;
-import $ from 'jquery';
 
 const service = new SampleDataService();
+const scorer  = new Scorer(WEIGHTS);
 const view    = new BootstrapView($(container), WEIGHTS);
-const reconciler = new Reconciler(service, view);
+const reconciler = new Reconciler(service, view, scorer);
 
 reconciler.init();

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -1,17 +1,18 @@
-import { IService, IView, Item, Candidate, Match, ActionEvent } from './types';
-
-const WEIGHTS = { EXACT: 100, WHITESPACE: 80, CONTAINS: 30 } as const;
+import { IService, IView, Item, Match, ActionEvent } from './types';
+import { Scorer } from './scorer';
 
 export class Reconciler {
-    readonly WEIGHTS = WEIGHTS;
-
     private position = 0;
     private listA: Item[] = [];
     private listB: Item[] = [];
     private readonly memento: Match[] = [];
     private readonly idProperty = 'id';
 
-    constructor(private readonly service: IService, private readonly view: IView) {
+    constructor(
+        private readonly service: IService,
+        private readonly view: IView,
+        private readonly scorer: Scorer,
+    ) {
         view.onAction('next',  () => this.next());
         view.onAction('prev',  () => this.prev());
         view.onAction('undo',  () => this.undo());
@@ -67,47 +68,6 @@ export class Reconciler {
 
     private redraw(): void {
         const matchItem = this.listA[this.position];
-        this.view.load(matchItem, this.getCandidates(matchItem, this.listB), this.listA, this.listB, this.memento);
-    }
-
-    private getCandidates(matchItem: Item, list: Item[]): Candidate[] {
-        if (matchItem == null) return [];
-        const result = list.map(item => {
-            const candidate: Record<string, unknown> = {};
-            const weights: Record<string, number> = {};
-            let matchTotal = 0;
-            Object.keys(item).forEach(key => {
-                candidate[key] = item[key];
-                if (key !== this.idProperty) {
-                    weights[key] = this.getWeight(item[key], matchItem[key]);
-                    matchTotal += weights[key];
-                }
-            });
-            weights['matchTotal'] = matchTotal;
-            candidate['weights'] = weights;
-            return candidate as Candidate;
-        });
-        return result
-            .filter(item => item.weights['matchTotal'] > 0)
-            .sort((a, b) => b.weights['matchTotal'] - a.weights['matchTotal']);
-    }
-
-    private getWeight(cell1: unknown, cell2: unknown): number {
-        if (cell1 == null) return 0;
-        if (cell2 == null) return 0;
-        if (cell1 === cell2) return WEIGHTS.EXACT;
-        if (this.isSameWs(cell1, cell2)) return WEIGHTS.WHITESPACE;
-        if (this.doesContain(cell1, cell2)) return WEIGHTS.CONTAINS;
-        return 0;
-    }
-
-    private isSameWs(cell1: unknown, cell2: unknown): boolean {
-        return String(cell1).toUpperCase().replace(/\s/g, '') === String(cell2).toUpperCase().replace(/\s/g, '');
-    }
-
-    private doesContain(cell1: unknown, cell2: unknown): boolean {
-        const s1 = String(cell1).toUpperCase();
-        const s2 = String(cell2).toUpperCase();
-        return s1.includes(s2) || s2.includes(s1);
+        this.view.load(matchItem, this.scorer.getCandidates(matchItem, this.listB), this.listA, this.listB, this.memento);
     }
 }

--- a/src/scorer.ts
+++ b/src/scorer.ts
@@ -1,0 +1,46 @@
+import { Item, Candidate, Weights } from './types';
+
+export class Scorer {
+    constructor(private readonly weights: Weights) {}
+
+    getWeight(cell1: unknown, cell2: unknown): number {
+        if (cell1 == null) return 0;
+        if (cell2 == null) return 0;
+        if (cell1 === cell2) return this.weights.EXACT;
+        if (this.isSameWs(cell1, cell2)) return this.weights.WHITESPACE;
+        if (this.doesContain(cell1, cell2)) return this.weights.CONTAINS;
+        return 0;
+    }
+
+    isSameWs(cell1: unknown, cell2: unknown): boolean {
+        return String(cell1).toUpperCase().replace(/\s/g, '') === String(cell2).toUpperCase().replace(/\s/g, '');
+    }
+
+    doesContain(cell1: unknown, cell2: unknown): boolean {
+        const s1 = String(cell1).toUpperCase();
+        const s2 = String(cell2).toUpperCase();
+        return s1.includes(s2) || s2.includes(s1);
+    }
+
+    getCandidates(matchItem: Item, list: Item[]): Candidate[] {
+        if (matchItem == null) return [];
+        const idProperty = 'id';
+        return list.map(item => {
+            const candidate: Record<string, unknown> = {};
+            const weights: Record<string, number> = {};
+            let matchTotal = 0;
+            Object.keys(item).forEach(key => {
+                candidate[key] = item[key];
+                if (key !== idProperty) {
+                    weights[key] = this.getWeight(item[key], matchItem[key]);
+                    matchTotal += weights[key];
+                }
+            });
+            weights['matchTotal'] = matchTotal;
+            candidate['weights'] = weights;
+            return candidate as Candidate;
+        })
+        .filter(item => item.weights['matchTotal'] > 0)
+        .sort((a, b) => b.weights['matchTotal'] - a.weights['matchTotal']);
+    }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,9 @@
+export interface Weights {
+    EXACT: number;
+    WHITESPACE: number;
+    CONTAINS: number;
+}
+
 export type ActionType = 'next' | 'prev' | 'undo' | 'match';
 
 export interface ActionEvent {


### PR DESCRIPTION
## Summary

- Extracts `Scorer` class into `src/scorer.ts` with `getCandidates`, `getWeight`, `isSameWs`, and `doesContain`; weights injected via constructor satisfying OCP
- `Reconciler` constructor now accepts `Scorer` as a third argument; all internal scoring methods and the hardcoded `WEIGHTS` constant removed (SRP)
- `Weights` interface moved from `BootstrapView` into `src/types.ts`; single `WEIGHTS` constant in `main.ts` wires `Scorer`, `BootstrapView`, and `Reconciler`

## Test plan

- [x] 18 new unit tests in `scorer.test.js` (8 TDD red→green cycles covering all public methods)
- [x] `reconcile.test.js` updated: `Scorer` injected in all constructor calls, `WEIGHTS` block removed, scoring integration tests retained
- [x] `npm test` — 51 tests pass (7 suites)
- [x] `tsc --noEmit` exits 0
- [x] `npm run build` exits 0

Part of modernisation plan — PR 3 of 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)