### PR TITLE
Add NICKNAME and TRANSPOSITION scorers (issues #21, #38)

### DIFF
--- a/scorer.test.js
+++ b/scorer.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { Scorer } from './src/scorer';
 
-const WEIGHTS = { EXACT: 100, WHITESPACE: 80, CONTAINS: 30 };
+const WEIGHTS = { EXACT: 100, WHITESPACE: 80, NICKNAME: 60, CONTAINS: 30, TRANSPOSITION: 20 };
 
 describe('Scorer', () => {
     let scorer;
@@ -30,6 +30,62 @@ describe('Scorer', () => {
 
         it('returns 0 when values share no match', () => {
             expect(scorer.getWeight('Alice', 'Bob')).toBe(0);
+        });
+
+        it('returns TRANSPOSITION weight for a single adjacent character swap', () => {
+            expect(scorer.getWeight('Oliver', 'Oilver')).toBe(20);
+        });
+
+        it('returns TRANSPOSITION weight when normalised strings differ by one adjacent swap', () => {
+            expect(scorer.getWeight('Oli ver', 'Oilver')).toBe(20);
+        });
+
+        it('returns 0 when strings differ by more than one adjacent swap', () => {
+            expect(scorer.getWeight('Abcd', 'Badc')).toBe(0);
+        });
+    });
+
+    describe('isNickname()', () => {
+        it('returns true for Nick / Nicholas', () => {
+            expect(scorer.isNickname('Nick', 'Nicholas')).toBe(true);
+        });
+
+        it('is case-insensitive', () => {
+            expect(scorer.isNickname('nick', 'NICHOLAS')).toBe(true);
+        });
+
+        it('returns true for Bill / William', () => {
+            expect(scorer.isNickname('Bill', 'William')).toBe(true);
+        });
+
+        it('returns true for Bob / Robert', () => {
+            expect(scorer.isNickname('Bob', 'Robert')).toBe(true);
+        });
+
+        it('returns true for Jim / James', () => {
+            expect(scorer.isNickname('Jim', 'James')).toBe(true);
+        });
+
+        it('returns true for Kate / Katherine', () => {
+            expect(scorer.isNickname('Kate', 'Katherine')).toBe(true);
+        });
+
+        it('returns false for names in different groups', () => {
+            expect(scorer.isNickname('Nick', 'William')).toBe(false);
+        });
+
+        it('returns false for unknown names', () => {
+            expect(scorer.isNickname('Alice', 'Alicia')).toBe(false);
+        });
+    });
+
+    describe('getWeight() — NICKNAME priority', () => {
+        it('returns NICKNAME weight (60) for Nick / Nicholas', () => {
+            expect(scorer.getWeight('Nick', 'Nicholas')).toBe(60);
+        });
+
+        it('NICKNAME scores higher than CONTAINS', () => {
+            expect(scorer.getWeight('Nick', 'Nicholas')).toBeGreaterThan(scorer.getWeight('Anders', 'Anderson'));
         });
     });
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import { Reconciler } from './reconciler';
 import { Scorer } from './scorer';
 import 'bootstrap/dist/css/bootstrap.min.css';
 
-const WEIGHTS = { EXACT: 100, WHITESPACE: 80, CONTAINS: 30 };
+const WEIGHTS = { EXACT: 100, WHITESPACE: 80, NICKNAME: 60, CONTAINS: 30, TRANSPOSITION: 20 };
 
 const container = document.querySelector<HTMLElement>('.reconcile')!;
 

--- a/src/scorer.ts
+++ b/src/scorer.ts
@@ -1,5 +1,16 @@
 import { Item, Candidate, Weights } from './types';
 
+const NICKNAME_GROUPS: string[][] = [
+    ['NICK', 'NICHOLAS'],
+    ['BILL', 'WILLIAM', 'WILL', 'WILLIE'],
+    ['BOB', 'ROBERT', 'ROB', 'BOBBY'],
+    ['JIM', 'JAMES', 'JIMMY'],
+    ['KATE', 'KATHERINE', 'KATHY', 'KATIE', 'KAT'],
+];
+
+const NICKNAME_MAP = new Map<string, number>();
+NICKNAME_GROUPS.forEach((group, idx) => group.forEach(name => NICKNAME_MAP.set(name, idx)));
+
 export class Scorer {
     constructor(private readonly weights: Weights) {}
 
@@ -8,12 +19,39 @@ export class Scorer {
         if (cell2 == null) return 0;
         if (cell1 === cell2) return this.weights.EXACT;
         if (this.isSameWs(cell1, cell2)) return this.weights.WHITESPACE;
+        if (this.isNickname(cell1, cell2)) return this.weights.NICKNAME;
         if (this.doesContain(cell1, cell2)) return this.weights.CONTAINS;
+        if (this.isTransposition(cell1, cell2)) return this.weights.TRANSPOSITION;
         return 0;
     }
 
     isSameWs(cell1: unknown, cell2: unknown): boolean {
         return String(cell1).toUpperCase().replace(/\s/g, '') === String(cell2).toUpperCase().replace(/\s/g, '');
+    }
+
+    isNickname(cell1: unknown, cell2: unknown): boolean {
+        const s1 = String(cell1).toUpperCase().replace(/\s/g, '');
+        const s2 = String(cell2).toUpperCase().replace(/\s/g, '');
+        const g1 = NICKNAME_MAP.get(s1);
+        return g1 !== undefined && g1 === NICKNAME_MAP.get(s2);
+    }
+
+    isTransposition(cell1: unknown, cell2: unknown): boolean {
+        const s1 = String(cell1).toUpperCase().replace(/\s/g, '');
+        const s2 = String(cell2).toUpperCase().replace(/\s/g, '');
+        if (s1.length !== s2.length) return false;
+        let diffs = 0;
+        for (let i = 0; i < s1.length; i++) {
+            if (s1[i] !== s2[i]) diffs++;
+            if (diffs > 2) return false;
+        }
+        if (diffs !== 2) return false;
+        // find the two differing positions and check they are adjacent and swapped
+        const pos: number[] = [];
+        for (let i = 0; i < s1.length; i++) {
+            if (s1[i] !== s2[i]) pos.push(i);
+        }
+        return pos[1] === pos[0] + 1 && s1[pos[0]] === s2[pos[1]] && s1[pos[1]] === s2[pos[0]];
     }
 
     doesContain(cell1: unknown, cell2: unknown): boolean {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,9 @@
 export interface Weights {
     EXACT: number;
     WHITESPACE: number;
+    NICKNAME: number;
     CONTAINS: number;
+    TRANSPOSITION: number;
 }
 
 export type ActionType = 'next' | 'prev' | 'undo' | 'match';


### PR DESCRIPTION
## Summary

- **NICKNAME (weight 60)** — lookup-table equivalence groups; sits between WHITESPACE and CONTAINS in priority. Groups: Nick/Nicholas, Bill/William, Bob/Robert, Jim/James, Kate/Katherine (+ common variants). Case-insensitive, whitespace-normalised.
- **TRANSPOSITION (weight 20)** — exactly one adjacent character swap (e.g. `Oliver`→`Oilver`); sits below CONTAINS. Normalises before comparing. Returns 0 for >1 swap or length mismatch.
- **`Weights` interface** extended with `NICKNAME` and `TRANSPOSITION` fields; `main.ts` passes `NICKNAME: 60, TRANSPOSITION: 20`.
- **Priority order**: EXACT (100) → WHITESPACE (80) → NICKNAME (60) → CONTAINS (30) → TRANSPOSITION (20) → 0

## Test plan

- [x] `npm test` — 74 tests, all pass (13 new)
- [x] `tsc --noEmit` — exits 0
- [x] `npm run build` — exits 0

Closes #21
Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)