### PR TITLE
Rename 'Next' button to 'No Match' (closes #45)

### DIFF
--- a/reconcileBootstrapView.js
+++ b/reconcileBootstrapView.js
@@ -26,10 +26,10 @@
                 matchDiv.append(cellDiv);
             }
         });
-        matchDiv.append($('<div class="col-md-1"><button class="btn" accesskey="n">Next</button></div>'));
+        matchDiv.append($('<div class="col-md-1"><button class="btn" accesskey="n">No Match</button></div>'));
         matchDiv.append($('<div class="col-md-1"><button class="btn" accesskey="p">Prev</button></div>'));
         matchDiv.append($('<div class="col-md-1"><button class="btn" accesskey="u">Undo</button></div>'));
-        $(matchDiv).find('button:contains("Next")').on('click', next);
+        $(matchDiv).find('button:contains("No Match")').on('click', next);
         $(matchDiv).find('button:contains("Prev")').on('click', prev);
         $(matchDiv).find('button:contains("Undo")').on('click', undo);
         if (!canUndo) {

--- a/reconcileBootstrapView.test.js
+++ b/reconcileBootstrapView.test.js
@@ -70,6 +70,18 @@ describe('BootstrapView', () => {
             expect(undoBtn.disabled).toBe(true);
         });
 
+        it('labels the no-match button "No Match"', () => {
+            view.load(matchItem, twoCandidates, [matchItem], [], []);
+            const noMatchBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent === 'No Match');
+            expect(noMatchBtn).toBeDefined();
+        });
+
+        it('assigns accesskey="n" to the No Match button', () => {
+            view.load(matchItem, twoCandidates, [matchItem], [], []);
+            const noMatchBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent === 'No Match');
+            expect(noMatchBtn?.getAttribute('accesskey')).toBe('n');
+        });
+
         it('enables the Undo button when memento has entries', () => {
             const memento = [{ a: { id: '0', name: 'Alice' }, b: { id: '1', name: 'Alice' } }];
             view.load(matchItem, twoCandidates, [matchItem], [], memento);

--- a/src/bootstrapView.ts
+++ b/src/bootstrapView.ts
@@ -69,7 +69,7 @@ export class BootstrapView implements IView {
         const nextBtn = document.createElement('button');
         nextBtn.className = 'btn';
         nextBtn.setAttribute('accesskey', 'n');
-        nextBtn.textContent = 'Next';
+        nextBtn.textContent = 'No Match';
         nextBtn.addEventListener('click', () => this.next());
 
         const prevBtn = document.createElement('button');


### PR DESCRIPTION
## Summary

- Renames the "Next" button to "No Match" in `src/bootstrapView.ts` (TypeScript view) and the legacy `reconcileBootstrapView.js`
- Adds two tests covering the new label and its `accesskey="n"` attribute

## Test plan

- [x] `reconcileBootstrapView.test.js` — new tests assert button text is "No Match" and `accesskey` is `"n"`
- [x] All 79 tests pass (`npm test`)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)