### PR TITLE
Add currentUsername to set() call for backend auditing (closes #46)

### DIFF
--- a/reconcile.test.js
+++ b/reconcile.test.js
@@ -30,7 +30,7 @@ describe('Reconciler', () => {
         );
         view = makeView();
         scorer = new Scorer(WEIGHTS);
-        reconcile = new Reconciler(service, view, scorer);
+        reconcile = new Reconciler(service, view, scorer, 'testuser');
         await reconcile.init();
     });
 
@@ -114,6 +114,11 @@ describe('Reconciler', () => {
             const [, , listA, listB] = view.load.mock.lastCall;
             expect(listA.map(i => i.id)).toEqual([]);
             expect(listB.map(i => i.id)).toEqual([]);
+        });
+
+        it('calls service.set() with the current username as the third argument', () => {
+            reconcile.match({ a: '5', b: 'A' });
+            expect(service.set).toHaveBeenCalledWith('5', 'A', 'testuser');
         });
 
         it('restores items to listA and listB after undo', () => {

--- a/reconcileTestService.test.js
+++ b/reconcileTestService.test.js
@@ -11,9 +11,13 @@ describe('SampleDataService', () => {
     describe('set()', () => {
         it('does not call alert()', () => {
             vi.stubGlobal('alert', vi.fn());
-            service.set('1', 'A');
+            service.set('1', 'A', 'testuser');
             expect(global.alert).not.toHaveBeenCalled();
             vi.unstubAllGlobals();
+        });
+
+        it('accepts a currentUsername argument without throwing', () => {
+            expect(() => service.set('1', 'A', 'testuser')).not.toThrow();
         });
     });
 

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -12,6 +12,7 @@ export class Reconciler {
         private readonly service: IService,
         private readonly view: IView,
         private readonly scorer: Scorer,
+        private readonly currentUsername: string = '',
     ) {
         view.onAction('next',  () => this.next());
         view.onAction('prev',  () => this.prev());
@@ -45,7 +46,7 @@ export class Reconciler {
     match(event: ActionEvent): void {
         const { a: aId, b: bId } = event;
         if (!aId || !bId) return;
-        this.service.set(aId, bId);
+        this.service.set(aId, bId, this.currentUsername);
         const lastMatch: Match = {
             a: this.listA.find(item => item[this.idProperty] === aId)!,
             b: this.listB.find(item => item[this.idProperty] === bId)!,

--- a/src/sampleDataService.ts
+++ b/src/sampleDataService.ts
@@ -63,8 +63,8 @@ export class SampleDataService implements IService {
         };
     }
 
-    set(aId: string, bId: string): void {
-        console.log(`matching ${aId} => ${bId}`);
+    set(aId: string, bId: string, currentUsername: string): void {
+        console.log(`matching ${aId} => ${bId} by ${currentUsername}`);
     }
 
     undo(aId: string, bId: string): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,7 +30,7 @@ export interface Match {
 
 export interface IService {
     load(): Promise<{ a: Item[]; b: Item[] }>;
-    set(aId: string, bId: string): void;
+    set(aId: string, bId: string, currentUsername: string): void;
     undo(aId: string, bId: string): void;
 }
 


### PR DESCRIPTION
## Summary

- Adds `currentUsername: string` as a third parameter to `IService.set()` and `SampleDataService.set()`
- `Reconciler` accepts `currentUsername` as an optional constructor parameter (defaults to `''`) and passes it through on every `match()` call
- Consumers that provide a real service implementation can now record who performed each reconciliation action

## Test plan

- [x] New test: `service.set()` receives the username as the third argument when `Reconciler.match()` is called
- [x] New test: `SampleDataService.set()` accepts `currentUsername` without throwing
- [x] All 81 existing tests continue to pass
- [x] TypeScript interface (`IService`) updated to enforce the new signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)