### PR TITLE
Add differences array to service.set() for auditing

### DIFF
--- a/reconcile.test.js
+++ b/reconcile.test.js
@@ -118,7 +118,74 @@ describe('Reconciler', () => {
 
         it('calls service.set() with the current username as the third argument', () => {
             reconcile.match({ a: '5', b: 'A' });
-            expect(service.set).toHaveBeenCalledWith('5', 'A', 'testuser');
+            expect(service.set).toHaveBeenCalledWith('5', 'A', 'testuser', expect.any(Array));
+        });
+
+        it('passes a differences array as the fourth argument to service.set()', () => {
+            reconcile.match({ a: '5', b: 'A' });
+            const differences = service.set.mock.calls[0][3];
+            expect(Array.isArray(differences)).toBe(true);
+        });
+
+        it('includes fields that differ between System A and System B in the differences array', () => {
+            reconcile.match({ a: '5', b: 'A' });
+            const differences = service.set.mock.calls[0][3];
+            const fields = differences.map(d => d.field);
+            expect(fields).toContain('firstName');
+            expect(fields).toContain('lastName');
+        });
+
+        it('each difference entry has field, aValue, and bValue', () => {
+            reconcile.match({ a: '5', b: 'A' });
+            const differences = service.set.mock.calls[0][3];
+            expect(differences.length).toBeGreaterThan(0);
+            for (const diff of differences) {
+                expect(diff).toHaveProperty('field');
+                expect(diff).toHaveProperty('aValue');
+                expect(diff).toHaveProperty('bValue');
+            }
+        });
+
+        it('excludes fields that match exactly from the differences array', async () => {
+            const svc = makeService(
+                [{ id: '1', name: 'Alice', city: 'Paris' }],
+                [{ id: 'X', name: 'Alice', city: 'London' }]
+            );
+            const v = makeView();
+            const r = new Reconciler(svc, v, new Scorer(WEIGHTS), 'user');
+            await r.init();
+            r.match({ a: '1', b: 'X' });
+            const differences = svc.set.mock.calls[0][3];
+            const fields = differences.map(d => d.field);
+            expect(fields).not.toContain('name');
+            expect(fields).toContain('city');
+        });
+
+        it('records correct aValue and bValue for each differing field', async () => {
+            const svc = makeService(
+                [{ id: '1', name: 'Alice', city: 'Paris' }],
+                [{ id: 'X', name: 'Alice', city: 'London' }]
+            );
+            const v = makeView();
+            const r = new Reconciler(svc, v, new Scorer(WEIGHTS), 'user');
+            await r.init();
+            r.match({ a: '1', b: 'X' });
+            const differences = svc.set.mock.calls[0][3];
+            const cityDiff = differences.find(d => d.field === 'city');
+            expect(cityDiff).toEqual({ field: 'city', aValue: 'Paris', bValue: 'London' });
+        });
+
+        it('passes an empty differences array when all fields match exactly', async () => {
+            const svc = makeService(
+                [{ id: '1', name: 'Alice', city: 'Paris' }],
+                [{ id: 'X', name: 'Alice', city: 'Paris' }]
+            );
+            const v = makeView();
+            const r = new Reconciler(svc, v, new Scorer(WEIGHTS), 'user');
+            await r.init();
+            r.match({ a: '1', b: 'X' });
+            const differences = svc.set.mock.calls[0][3];
+            expect(differences).toEqual([]);
         });
 
         it('restores items to listA and listB after undo', () => {

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -1,4 +1,4 @@
-import { IService, IView, Item, Match, ActionEvent } from './types';
+import { IService, IView, Item, Match, ActionEvent, Difference } from './types';
 import { Scorer } from './scorer';
 
 export class Reconciler {
@@ -43,14 +43,25 @@ export class Reconciler {
         this.redraw();
     }
 
+    private computeDifferences(a: Item, b: Item): Difference[] {
+        const differences: Difference[] = [];
+        for (const field of Object.keys(a)) {
+            if (field === this.idProperty) continue;
+            if (a[field] !== b[field]) {
+                differences.push({ field, aValue: a[field], bValue: b[field] });
+            }
+        }
+        return differences;
+    }
+
     match(event: ActionEvent): void {
         const { a: aId, b: bId } = event;
         if (!aId || !bId) return;
-        this.service.set(aId, bId, this.currentUsername);
-        const lastMatch: Match = {
-            a: this.listA.find(item => item[this.idProperty] === aId)!,
-            b: this.listB.find(item => item[this.idProperty] === bId)!,
-        };
+        const aItem = this.listA.find(item => item[this.idProperty] === aId)!;
+        const bItem = this.listB.find(item => item[this.idProperty] === bId)!;
+        const differences = this.computeDifferences(aItem, bItem);
+        this.service.set(aId, bId, this.currentUsername, differences);
+        const lastMatch: Match = { a: aItem, b: bItem };
         this.memento.push(lastMatch);
         this.listA = this.listA.filter(item => item[this.idProperty] !== aId);
         this.listB = this.listB.filter(item => item[this.idProperty] !== bId);

--- a/src/sampleDataService.ts
+++ b/src/sampleDataService.ts
@@ -1,4 +1,4 @@
-import { IService, Item } from './types';
+import { IService, Item, Difference } from './types';
 
 interface RawA {
     FirstName: string;
@@ -63,8 +63,8 @@ export class SampleDataService implements IService {
         };
     }
 
-    set(aId: string, bId: string, currentUsername: string): void {
-        console.log(`matching ${aId} => ${bId} by ${currentUsername}`);
+    set(aId: string, bId: string, currentUsername: string, differences: Difference[]): void {
+        console.log(`matching ${aId} => ${bId} by ${currentUsername}`, differences);
     }
 
     undo(aId: string, bId: string): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,9 +28,15 @@ export interface Match {
     b: Item;
 }
 
+export interface Difference {
+    field: string;
+    aValue: unknown;
+    bValue: unknown;
+}
+
 export interface IService {
     load(): Promise<{ a: Item[]; b: Item[] }>;
-    set(aId: string, bId: string, currentUsername: string): void;
+    set(aId: string, bId: string, currentUsername: string, differences: Difference[]): void;
     undo(aId: string, bId: string): void;
 }
 


### PR DESCRIPTION
## Summary
- Adds a `Difference` interface to `types.ts` (`field`, `aValue`, `bValue`)
- Updates `IService.set()` to accept a `differences: Difference[]` fourth argument
- `Reconciler.match()` computes field-level differences between the matched System A and System B items and passes them to `service.set()`
- `SampleDataService.set()` updated to match the new signature

## Test plan
- [x] New tests verify differences array is passed as 4th argument to `service.set()`
- [x] Fields that differ between A and B are included; fields that match exactly are excluded
- [x] Each difference entry has `field`, `aValue`, and `bValue`
- [x] Empty array passed when all fields match exactly
- [x] All 87 tests pass

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)