### PR TITLE
Add per-column scorer weight overrides (closes #48)

### DIFF
--- a/scorer.test.js
+++ b/scorer.test.js
@@ -177,4 +177,46 @@ describe('Scorer', () => {
             expect(scorer.getCandidates(null, [{ id: 'X', name: 'Alice' }])).toEqual([]);
         });
     });
+
+    describe('per-column weights', () => {
+        it('uses column-specific EXACT weight when provided', () => {
+            const scorer = new Scorer(WEIGHTS, { name: { EXACT: 200 } });
+            const matchItem = { id: '1', name: 'Alice' };
+            const list = [{ id: 'X', name: 'Alice' }];
+            const [c] = scorer.getCandidates(matchItem, list);
+            expect(c.weights.name).toBe(200);
+        });
+
+        it('falls back to global weights for columns without overrides', () => {
+            const scorer = new Scorer(WEIGHTS, { name: { EXACT: 200 } });
+            const matchItem = { id: '1', name: 'Alice', city: 'Paris' };
+            const list = [{ id: 'X', name: 'Alice', city: 'Paris' }];
+            const [c] = scorer.getCandidates(matchItem, list);
+            expect(c.weights.city).toBe(100);
+        });
+
+        it('uses column-specific CONTAINS weight in isolation', () => {
+            const scorer = new Scorer(WEIGHTS, { name: { CONTAINS: 50 } });
+            const matchItem = { id: '1', name: 'Anders' };
+            const list = [{ id: 'X', name: 'Anderson' }];
+            const [c] = scorer.getCandidates(matchItem, list);
+            expect(c.weights.name).toBe(50);
+        });
+
+        it('reflects column weight override in matchTotal', () => {
+            const scorer = new Scorer(WEIGHTS, { name: { EXACT: 200 } });
+            const matchItem = { id: '1', name: 'Alice', city: 'Paris' };
+            const list = [{ id: 'X', name: 'Alice', city: 'Paris' }];
+            const [c] = scorer.getCandidates(matchItem, list);
+            expect(c.weights.matchTotal).toBe(300); // 200 (name) + 100 (city)
+        });
+
+        it('behaves identically to global weights when no column overrides given', () => {
+            const scorer = new Scorer(WEIGHTS);
+            const matchItem = { id: '1', name: 'Alice' };
+            const list = [{ id: 'X', name: 'Alice' }];
+            const [c] = scorer.getCandidates(matchItem, list);
+            expect(c.weights.name).toBe(100);
+        });
+    });
 });

--- a/src/scorer.ts
+++ b/src/scorer.ts
@@ -1,20 +1,24 @@
-import { Item, Candidate, Weights } from './types';
+import { Item, Candidate, Weights, ColumnWeights } from './types';
 import NICKNAME_GROUPS from './nicknames.json';
 
 const NICKNAME_MAP = new Map<string, number>();
 (NICKNAME_GROUPS as string[][]).forEach((group, idx) => group.forEach(name => NICKNAME_MAP.set(name, idx)));
 
 export class Scorer {
-    constructor(private readonly weights: Weights) {}
+    constructor(
+        private readonly weights: Weights,
+        private readonly columnWeights: ColumnWeights = {},
+    ) {}
 
-    getWeight(cell1: unknown, cell2: unknown): number {
+    getWeight(cell1: unknown, cell2: unknown, column?: string): number {
         if (cell1 == null) return 0;
         if (cell2 == null) return 0;
-        if (cell1 === cell2) return this.weights.EXACT;
-        if (this.isSameWs(cell1, cell2)) return this.weights.WHITESPACE;
-        if (this.isNickname(cell1, cell2)) return this.weights.NICKNAME;
-        if (this.doesContain(cell1, cell2)) return this.weights.CONTAINS;
-        if (this.isTransposition(cell1, cell2)) return this.weights.TRANSPOSITION;
+        const w = column ? { ...this.weights, ...this.columnWeights[column] } : this.weights;
+        if (cell1 === cell2) return w.EXACT;
+        if (this.isSameWs(cell1, cell2)) return w.WHITESPACE;
+        if (this.isNickname(cell1, cell2)) return w.NICKNAME;
+        if (this.doesContain(cell1, cell2)) return w.CONTAINS;
+        if (this.isTransposition(cell1, cell2)) return w.TRANSPOSITION;
         return 0;
     }
 
@@ -63,7 +67,7 @@ export class Scorer {
             Object.keys(item).forEach(key => {
                 candidate[key] = item[key];
                 if (key !== idProperty) {
-                    weights[key] = this.getWeight(item[key], matchItem[key]);
+                    weights[key] = this.getWeight(item[key], matchItem[key], key);
                     matchTotal += weights[key];
                 }
             });

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,8 @@ export interface Weights {
     TRANSPOSITION: number;
 }
 
+export type ColumnWeights = Record<string, Partial<Weights>>;
+
 export type ActionType = 'next' | 'prev' | 'undo' | 'match';
 
 export interface ActionEvent {


### PR DESCRIPTION
## Summary

- Adds optional `ColumnWeights` type (`Record<string, Partial<Weights>>`) to `src/types.ts`
- `Scorer` constructor now accepts a second optional `columnWeights` parameter
- `getWeight()` merges column-specific overrides with global weights at call time; falls back to global weights for unspecified columns
- `getCandidates()` passes the column key to `getWeight()` so per-column weights are applied automatically

## Test plan

- [x] 5 new tests cover: column-specific EXACT weight, column-specific CONTAINS weight, fallback to global weights, matchTotal reflects overrides, no-override parity
- [x] All 39 tests pass (`npx vitest run scorer.test.js`)
- [x] No existing tests modified (fully backward-compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)