### PR TITLE
Replace scorer colors with per-column mismatch background colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,7 @@
 <html>
     <head>
         <title>reconcile test page</title>
-        <style>
-            .match-same { background-color: #0f0; }
 
-            .match-samews { background-color: #ff0; }
-
-            .match-contains { background-color: #ffc; }
-        </style>
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" type="text/javascript"></script>
     </head>
     <body>

--- a/reconcileBootstrapView.test.js
+++ b/reconcileBootstrapView.test.js
@@ -89,18 +89,95 @@ describe('BootstrapView', () => {
             expect(undoBtn.disabled).toBe(false);
         });
 
-        it('applies match-same class to cells with EXACT weight', () => {
-            const candidates = [{ id: '1', name: 'Alice', weights: { name: WEIGHTS.EXACT, matchTotal: 100 } }];
-            view.load(matchItem, candidates, [matchItem], [], []);
-            const sameCells = container.querySelectorAll('.match-same');
-            expect(sameCells.length).toBeGreaterThan(0);
-        });
-
         it('clears the container on subsequent load() calls', () => {
             view.load(matchItem, twoCandidates, [matchItem], [], []);
             view.load(matchItem, twoCandidates, [matchItem], [], []);
             const matchButtons = Array.from(container.querySelectorAll('button')).filter(b => b.textContent === 'Match');
             expect(matchButtons.length).toBe(2);
+        });
+    });
+
+    describe('per-column mismatch coloring', () => {
+        let container, view;
+
+        beforeEach(() => {
+            container = makeContainer();
+            view = new BootstrapView(container, WEIGHTS);
+        });
+
+        const multiItem = { id: '0', name: 'Alice', city: 'NYC' };
+
+        const candidatesCityMismatch = [
+            { id: '1', name: 'Alice', city: 'LA', weights: { name: 100, city: 0, matchTotal: 100 } },
+        ];
+        const candidatesAllMatch = [
+            { id: '1', name: 'Alice', city: 'NYC', weights: { name: 100, city: 100, matchTotal: 200 } },
+        ];
+        const candidatesBothMismatch = [
+            { id: '1', name: 'Bob', city: 'LA', weights: { name: 0, city: 0, matchTotal: 0 } },
+        ];
+
+        function getRows() { return container.querySelectorAll('.row'); }
+        function cellByText(row, text) {
+            return Array.from(row.querySelectorAll('.col-md-1')).find(c => c.textContent === text);
+        }
+
+        it('does not apply scorer CSS classes', () => {
+            view.load(multiItem, candidatesCityMismatch, [multiItem], [], []);
+            expect(container.querySelectorAll('.match-same').length).toBe(0);
+            expect(container.querySelectorAll('.match-samews').length).toBe(0);
+            expect(container.querySelectorAll('.match-contains').length).toBe(0);
+        });
+
+        it('applies a background color to the System A cell for a mismatching column', () => {
+            view.load(multiItem, candidatesCityMismatch, [multiItem], [], []);
+            const systemARow = getRows()[0];
+            const cityCell = cellByText(systemARow, 'NYC');
+            expect(cityCell.style.backgroundColor).not.toBe('');
+        });
+
+        it('does not apply background color to the System A cell for a non-mismatching column', () => {
+            view.load(multiItem, candidatesCityMismatch, [multiItem], [], []);
+            const systemARow = getRows()[0];
+            const nameCell = cellByText(systemARow, 'Alice');
+            expect(nameCell.style.backgroundColor).toBe('');
+        });
+
+        it('applies the same color to non-matching System B cells in the same column', () => {
+            view.load(multiItem, candidatesCityMismatch, [multiItem], [], []);
+            const rows = getRows();
+            const systemARow = rows[0];
+            const candidateRow = rows[2]; // 0=SystemA, 1=Header, 2=first candidate
+            const systemACityColor = cellByText(systemARow, 'NYC').style.backgroundColor;
+            const candidateCityColor = cellByText(candidateRow, 'LA').style.backgroundColor;
+            expect(candidateCityColor).toBe(systemACityColor);
+        });
+
+        it('does not apply background color to matching System B cells', () => {
+            view.load(multiItem, candidatesCityMismatch, [multiItem], [], []);
+            const candidateRow = getRows()[2];
+            const nameCell = cellByText(candidateRow, 'Alice');
+            expect(nameCell.style.backgroundColor).toBe('');
+        });
+
+        it('applies no background color when all columns match', () => {
+            view.load(multiItem, candidatesAllMatch, [multiItem], [], []);
+            const systemARow = getRows()[0];
+            const dataCells = Array.from(systemARow.querySelectorAll('.col-md-1'))
+                .filter(c => c.querySelector('button') === null);
+            for (const cell of dataCells) {
+                expect(cell.style.backgroundColor).toBe('');
+            }
+        });
+
+        it('assigns distinct colors to different mismatching columns', () => {
+            view.load(multiItem, candidatesBothMismatch, [multiItem], [], []);
+            const systemARow = getRows()[0];
+            const nameColor = cellByText(systemARow, 'Alice').style.backgroundColor;
+            const cityColor = cellByText(systemARow, 'NYC').style.backgroundColor;
+            expect(nameColor).not.toBe('');
+            expect(cityColor).not.toBe('');
+            expect(nameColor).not.toBe(cityColor);
         });
     });
 });

--- a/src/bootstrapView.ts
+++ b/src/bootstrapView.ts
@@ -3,6 +3,7 @@ import { IView, Item, Candidate, Match, ActionType, ActionEvent, Weights } from 
 export class BootstrapView implements IView {
     private readonly idProperty = 'id';
     private readonly listeners: Partial<Record<ActionType, Array<(e: ActionEvent) => void>>> = {};
+    private readonly columnColors = ['#ffff00', '#add8e6', '#90ee90', '#ffb6c1', '#ffa07a', '#dda0dd'];
 
     constructor(
         private readonly masterDiv: HTMLElement,
@@ -12,9 +13,10 @@ export class BootstrapView implements IView {
     load(matchItem: Item, candidates: Candidate[], listA: Item[], listB: Item[], memento: Match[]): void {
         this.masterDiv.innerHTML = '';
         if (listA.length > 0) {
-            this.masterDiv.append(this.buildMatchLine(matchItem, memento.length > 0));
+            const mismatchColors = this.getMismatchColors(matchItem, candidates);
+            this.masterDiv.append(this.buildMatchLine(matchItem, memento.length > 0, mismatchColors));
             this.masterDiv.append(this.buildHeaderDiv(matchItem));
-            this.buildCandidates(matchItem, candidates).forEach(el => this.masterDiv.append(el));
+            this.buildCandidates(matchItem, candidates, mismatchColors).forEach(el => this.masterDiv.append(el));
             if (candidates.length === 1 || candidates[0].weights['matchTotal'] > candidates[1].weights['matchTotal']) {
                 const matchBtn = this.masterDiv.querySelector<HTMLButtonElement>('button[data-b]');
                 matchBtn?.focus();
@@ -56,12 +58,27 @@ export class BootstrapView implements IView {
         return elem;
     }
 
-    private buildMatchLine(matchItem: Item, canUndo: boolean): HTMLElement {
+    private getMismatchColors(matchItem: Item, candidates: Candidate[]): Record<string, string> {
+        const colors: Record<string, string> = {};
+        let colorIdx = 0;
+        Object.keys(matchItem)
+            .filter(k => k !== this.idProperty)
+            .forEach(key => {
+                if (candidates.some(c => c[key] !== matchItem[key])) {
+                    colors[key] = this.columnColors[colorIdx % this.columnColors.length];
+                    colorIdx++;
+                }
+            });
+        return colors;
+    }
+
+    private buildMatchLine(matchItem: Item, canUndo: boolean, mismatchColors: Record<string, string>): HTMLElement {
         const row = this.el('div', 'row');
         Object.keys(matchItem).forEach(key => {
             if (key !== this.idProperty) {
                 const cell = this.el('div', 'col-md-1');
                 cell.textContent = String(matchItem[key]);
+                if (mismatchColors[key]) cell.style.backgroundColor = mismatchColors[key];
                 row.append(cell);
             }
         });
@@ -110,16 +127,16 @@ export class BootstrapView implements IView {
         return header;
     }
 
-    private buildCandidates(matchItem: Item, candidates: Candidate[]): HTMLElement[] {
+    private buildCandidates(matchItem: Item, candidates: Candidate[], mismatchColors: Record<string, string>): HTMLElement[] {
         return candidates.map((item, index) => {
             const row = this.el('div', 'row');
             Object.keys(item).forEach(key => {
                 if (key !== this.idProperty && key !== 'weights') {
                     const cell = this.el('div', 'col-md-1');
                     cell.textContent = String(item[key]);
-                    if (item.weights[key] === this.weights.EXACT)      cell.classList.add('match-same');
-                    if (item.weights[key] === this.weights.WHITESPACE)  cell.classList.add('match-samews');
-                    if (item.weights[key] === this.weights.CONTAINS)    cell.classList.add('match-contains');
+                    if (mismatchColors[key] && item[key] !== matchItem[key]) {
+                        cell.style.backgroundColor = mismatchColors[key];
+                    }
                     row.append(cell);
                 }
             });


### PR DESCRIPTION
## Summary

- Removes all scorer-based CSS coloring (`match-same`, `match-samews`, `match-contains`) from both the TypeScript source and `index.html`
- Introduces a `getMismatchColors()` helper that identifies columns where any System B candidate differs from System A, assigning each such column a distinct color from a fixed palette (yellow → light blue → light green → …)
- System A fields for mismatching columns are highlighted with the column color; non-matching System B cells in that column get the same color; matching cells and columns with no mismatches stay neutral

## Test plan

- [x] `does not apply scorer CSS classes` — verifies `match-same`/`match-samews`/`match-contains` are gone
- [x] `applies a background color to the System A cell for a mismatching column`
- [x] `does not apply background color to the System A cell for a non-mismatching column`
- [x] `applies the same color to non-matching System B cells in the same column`
- [x] `does not apply background color to matching System B cells`
- [x] `applies no background color when all columns match`
- [x] `assigns distinct colors to different mismatching columns`
- [x] All 18 existing tests pass

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)