### PR TITLE
Add Bootstrap variant classes to all buttons and rename Prev to Previous

### DIFF
--- a/reconcileBootstrapView.test.js
+++ b/reconcileBootstrapView.test.js
@@ -95,6 +95,43 @@ describe('BootstrapView', () => {
             const matchButtons = Array.from(container.querySelectorAll('button')).filter(b => b.textContent === 'Match');
             expect(matchButtons.length).toBe(2);
         });
+
+        it('labels the previous button "Previous"', () => {
+            view.load(matchItem, twoCandidates, [matchItem], [], []);
+            const prevBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent === 'Previous');
+            expect(prevBtn).toBeDefined();
+        });
+
+        it('does not render a button labelled "Prev"', () => {
+            view.load(matchItem, twoCandidates, [matchItem], [], []);
+            const prevBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent === 'Prev');
+            expect(prevBtn).toBeUndefined();
+        });
+
+        it('gives the No Match button a btn-warning class', () => {
+            view.load(matchItem, twoCandidates, [matchItem], [], []);
+            const btn = Array.from(container.querySelectorAll('button')).find(b => b.textContent === 'No Match');
+            expect(btn?.classList.contains('btn-warning')).toBe(true);
+        });
+
+        it('gives the Previous button a btn-secondary class', () => {
+            view.load(matchItem, twoCandidates, [matchItem], [], []);
+            const btn = Array.from(container.querySelectorAll('button')).find(b => b.textContent === 'Previous');
+            expect(btn?.classList.contains('btn-secondary')).toBe(true);
+        });
+
+        it('gives the Undo button a btn-secondary class', () => {
+            view.load(matchItem, twoCandidates, [matchItem], [], []);
+            const btn = Array.from(container.querySelectorAll('button')).find(b => b.textContent === 'Undo');
+            expect(btn?.classList.contains('btn-secondary')).toBe(true);
+        });
+
+        it('gives each Match button a btn-success class', () => {
+            view.load(matchItem, twoCandidates, [matchItem], [], []);
+            const matchBtns = Array.from(container.querySelectorAll('button')).filter(b => b.textContent === 'Match');
+            expect(matchBtns.length).toBeGreaterThan(0);
+            matchBtns.forEach(btn => expect(btn.classList.contains('btn-success')).toBe(true));
+        });
     });
 
     describe('per-column mismatch coloring', () => {

--- a/src/bootstrapView.ts
+++ b/src/bootstrapView.ts
@@ -84,19 +84,19 @@ export class BootstrapView implements IView {
         });
 
         const nextBtn = document.createElement('button');
-        nextBtn.className = 'btn';
+        nextBtn.className = 'btn btn-warning';
         nextBtn.setAttribute('accesskey', 'n');
         nextBtn.textContent = 'No Match';
         nextBtn.addEventListener('click', () => this.next());
 
         const prevBtn = document.createElement('button');
-        prevBtn.className = 'btn';
+        prevBtn.className = 'btn btn-secondary';
         prevBtn.setAttribute('accesskey', 'p');
-        prevBtn.textContent = 'Prev';
+        prevBtn.textContent = 'Previous';
         prevBtn.addEventListener('click', () => this.prev());
 
         const undoBtn = document.createElement('button');
-        undoBtn.className = 'btn';
+        undoBtn.className = 'btn btn-secondary';
         undoBtn.setAttribute('accesskey', 'u');
         undoBtn.textContent = 'Undo';
         undoBtn.addEventListener('click', () => this.undo());
@@ -141,7 +141,7 @@ export class BootstrapView implements IView {
                 }
             });
             const btn = document.createElement('button');
-            btn.className = 'btn';
+            btn.className = 'btn btn-success';
             if (index === 0) btn.setAttribute('accesskey', 'm');
             btn.setAttribute('data-a', String(matchItem[this.idProperty]));
             btn.setAttribute('data-b', String(item[this.idProperty]));


### PR DESCRIPTION
## Summary

- All buttons now carry a Bootstrap variant class so they render visibly:
  - **No Match** → `btn-warning` (amber — skip/caution)
  - **Previous** → `btn-secondary` (neutral navigation)
  - **Undo** → `btn-secondary` (neutral action)
  - **Match** → `btn-success` (green — positive confirmation)
- Renamed the **Prev** button label to **Previous**

## Test plan

- [x] `labels the previous button "Previous"`
- [x] `does not render a button labelled "Prev"`
- [x] `gives the No Match button a btn-warning class`
- [x] `gives the Previous button a btn-secondary class`
- [x] `gives the Undo button a btn-secondary class`
- [x] `gives each Match button a btn-success class`
- [x] All 24 tests pass

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)