### PR TITLE
Use full width of page for display

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     </head>
     <body>
         <div style="border: 1pt solid black; margin: 30px;">
-            <div class="reconcile container"></div>
+            <div class="reconcile container-fluid"></div>
         </div>
         <script type="module" src="/src/main.ts"></script>
     </body>

--- a/reconcileBootstrapView.test.js
+++ b/reconcileBootstrapView.test.js
@@ -96,6 +96,12 @@ describe('BootstrapView', () => {
             expect(matchButtons.length).toBe(2);
         });
 
+        it('uses col class on data cells instead of col-md-1', () => {
+            view.load(matchItem, twoCandidates, [matchItem], [], []);
+            expect(container.querySelectorAll('.col-md-1').length).toBe(0);
+            expect(container.querySelectorAll('.col').length).toBeGreaterThan(0);
+        });
+
         it('labels the previous button "Previous"', () => {
             view.load(matchItem, twoCandidates, [matchItem], [], []);
             const prevBtn = Array.from(container.querySelectorAll('button')).find(b => b.textContent === 'Previous');
@@ -156,7 +162,7 @@ describe('BootstrapView', () => {
 
         function getRows() { return container.querySelectorAll('.row'); }
         function cellByText(row, text) {
-            return Array.from(row.querySelectorAll('.col-md-1')).find(c => c.textContent === text);
+            return Array.from(row.querySelectorAll('.col')).find(c => c.textContent === text);
         }
 
         it('does not apply scorer CSS classes', () => {
@@ -200,7 +206,7 @@ describe('BootstrapView', () => {
         it('applies no background color when all columns match', () => {
             view.load(multiItem, candidatesAllMatch, [multiItem], [], []);
             const systemARow = getRows()[0];
-            const dataCells = Array.from(systemARow.querySelectorAll('.col-md-1'))
+            const dataCells = Array.from(systemARow.querySelectorAll('.col'))
                 .filter(c => c.querySelector('button') === null);
             for (const cell of dataCells) {
                 expect(cell.style.backgroundColor).toBe('');

--- a/src/bootstrapView.ts
+++ b/src/bootstrapView.ts
@@ -76,7 +76,7 @@ export class BootstrapView implements IView {
         const row = this.el('div', 'row');
         Object.keys(matchItem).forEach(key => {
             if (key !== this.idProperty) {
-                const cell = this.el('div', 'col-md-1');
+                const cell = this.el('div', 'col');
                 cell.textContent = String(matchItem[key]);
                 if (mismatchColors[key]) cell.style.backgroundColor = mismatchColors[key];
                 row.append(cell);
@@ -102,11 +102,11 @@ export class BootstrapView implements IView {
         undoBtn.addEventListener('click', () => this.undo());
         if (!canUndo) undoBtn.disabled = true;
 
-        const nextWrap = this.el('div', 'col-md-1');
+        const nextWrap = this.el('div', 'col');
         nextWrap.append(nextBtn);
-        const prevWrap = this.el('div', 'col-md-1');
+        const prevWrap = this.el('div', 'col');
         prevWrap.append(prevBtn);
-        const undoWrap = this.el('div', 'col-md-1');
+        const undoWrap = this.el('div', 'col');
         undoWrap.append(undoBtn);
 
         row.append(nextWrap, prevWrap, undoWrap);
@@ -119,7 +119,7 @@ export class BootstrapView implements IView {
         header.style.color = '#fff';
         Object.keys(matchItem).forEach(key => {
             if (key !== this.idProperty) {
-                const cell = this.el('div', 'col-md-1');
+                const cell = this.el('div', 'col');
                 cell.textContent = key;
                 header.append(cell);
             }
@@ -132,7 +132,7 @@ export class BootstrapView implements IView {
             const row = this.el('div', 'row');
             Object.keys(item).forEach(key => {
                 if (key !== this.idProperty && key !== 'weights') {
-                    const cell = this.el('div', 'col-md-1');
+                    const cell = this.el('div', 'col');
                     cell.textContent = String(item[key]);
                     if (mismatchColors[key] && item[key] !== matchItem[key]) {
                         cell.style.backgroundColor = mismatchColors[key];
@@ -147,7 +147,7 @@ export class BootstrapView implements IView {
             btn.setAttribute('data-b', String(item[this.idProperty]));
             btn.textContent = 'Match';
             btn.addEventListener('click', (e) => this.match(e));
-            const wrap = this.el('div', 'col-md-1');
+            const wrap = this.el('div', 'col');
             wrap.append(btn);
             row.append(wrap);
             return row;


### PR DESCRIPTION
## Summary

- **`index.html`** — changed `container` to `container-fluid` to remove Bootstrap's max-width cap and horizontal gutters
- **`bootstrapView.ts`** — changed `col-md-1` (fixed 1/12 width) to `col` (equal share of available width) on all data and button wrapper cells; cells now expand to fill the full row rather than capping at 8.33%

## Test plan

- [x] `uses col class on data cells instead of col-md-1` — confirms no `.col-md-1` elements are rendered and `.col` cells are present
- [x] All 25 tests pass (existing per-column coloring tests updated to use `.col` selector)

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)