### PR TITLE
Add visual separation between System A row and candidates

### DIFF
--- a/reconcileBootstrapView.test.js
+++ b/reconcileBootstrapView.test.js
@@ -113,6 +113,12 @@ describe('BootstrapView', () => {
             expect(container.querySelectorAll('tbody td').length).toBeGreaterThan(0);
         });
 
+        it('applies a bottom border to the System A row to separate it from candidates', () => {
+            view.load(matchItem, twoCandidates, [matchItem], [], []);
+            const systemARow = container.querySelectorAll('tbody tr')[0];
+            expect(systemARow.style.borderBottom).not.toBe('');
+        });
+
         it('does not render div.row or div.col elements', () => {
             view.load(matchItem, twoCandidates, [matchItem], [], []);
             expect(container.querySelectorAll('.row').length).toBe(0);

--- a/src/bootstrapView.ts
+++ b/src/bootstrapView.ts
@@ -100,6 +100,7 @@ export class BootstrapView implements IView {
 
     private buildMatchRow(matchItem: Item, canUndo: boolean, mismatchColors: Record<string, string>): HTMLTableRowElement {
         const tr = document.createElement('tr');
+        tr.style.borderBottom = '3px solid #333';
         Object.keys(matchItem).forEach(key => {
             if (key !== this.idProperty) {
                 const cell = this.td(String(matchItem[key]));


### PR DESCRIPTION
## Summary

- Adds `border-bottom: 3px solid #333` to the System A `<tr>` in `buildMatchRow`, drawing a clear visual divider between the item being matched and the ranked System B candidates below it.

## Test plan

- [x] `applies a bottom border to the System A row to separate it from candidates`
- [x] All 29 tests pass

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)