### PR TITLE
Move Previous and Undo buttons out of the table (closes #63)

### DIFF
--- a/reconcileBootstrapView.test.js
+++ b/reconcileBootstrapView.test.js
@@ -161,6 +161,28 @@ describe('BootstrapView', () => {
             expect(matchBtns.length).toBeGreaterThan(0);
             matchBtns.forEach(btn => expect(btn.classList.contains('btn-success')).toBe(true));
         });
+
+        it('renders Previous button outside the table', () => {
+            view.load(matchItem, twoCandidates, [matchItem], [], []);
+            const prevInsideTable = container.querySelector('table button[accesskey="p"]');
+            expect(prevInsideTable).toBeNull();
+            const prevOutside = Array.from(container.querySelectorAll('button')).find(b => b.textContent === 'Previous');
+            expect(prevOutside).toBeDefined();
+        });
+
+        it('renders Undo button outside the table', () => {
+            view.load(matchItem, twoCandidates, [matchItem], [], []);
+            const undoInsideTable = container.querySelector('table button[accesskey="u"]');
+            expect(undoInsideTable).toBeNull();
+            const undoOutside = Array.from(container.querySelectorAll('button')).find(b => b.textContent === 'Undo');
+            expect(undoOutside).toBeDefined();
+        });
+
+        it('keeps No Match button inside the table', () => {
+            view.load(matchItem, twoCandidates, [matchItem], [], []);
+            const noMatchInsideTable = container.querySelector('table button[accesskey="n"]');
+            expect(noMatchInsideTable).not.toBeNull();
+        });
     });
 
     describe('per-column mismatch coloring', () => {

--- a/src/bootstrapView.ts
+++ b/src/bootstrapView.ts
@@ -22,11 +22,15 @@ export class BootstrapView implements IView {
             table.append(thead);
 
             const tbody = document.createElement('tbody');
-            tbody.append(this.buildMatchRow(matchItem, memento.length > 0, mismatchColors));
+            tbody.append(this.buildMatchRow(matchItem, mismatchColors));
             this.buildCandidateRows(matchItem, candidates, mismatchColors).forEach(row => tbody.append(row));
             table.append(tbody);
 
             this.masterDiv.append(table);
+
+            const controlBar = document.createElement('div');
+            controlBar.append(this.buildPrevButton(), this.buildUndoButton(memento.length > 0));
+            this.masterDiv.append(controlBar);
 
             if (candidates.length === 1 || candidates[0].weights['matchTotal'] > candidates[1].weights['matchTotal']) {
                 const matchBtn = this.masterDiv.querySelector<HTMLButtonElement>('button[data-b]');
@@ -98,7 +102,7 @@ export class BootstrapView implements IView {
         return tr;
     }
 
-    private buildMatchRow(matchItem: Item, canUndo: boolean, mismatchColors: Record<string, string>): HTMLTableRowElement {
+    private buildMatchRow(matchItem: Item, mismatchColors: Record<string, string>): HTMLTableRowElement {
         const tr = document.createElement('tr');
         tr.style.borderBottom = '3px solid #333';
         Object.keys(matchItem).forEach(key => {
@@ -115,23 +119,29 @@ export class BootstrapView implements IView {
         nextBtn.textContent = 'No Match';
         nextBtn.addEventListener('click', () => this.next());
 
-        const prevBtn = document.createElement('button');
-        prevBtn.className = 'btn btn-secondary';
-        prevBtn.setAttribute('accesskey', 'p');
-        prevBtn.textContent = 'Previous';
-        prevBtn.addEventListener('click', () => this.prev());
-
-        const undoBtn = document.createElement('button');
-        undoBtn.className = 'btn btn-secondary';
-        undoBtn.setAttribute('accesskey', 'u');
-        undoBtn.textContent = 'Undo';
-        undoBtn.addEventListener('click', () => this.undo());
-        if (!canUndo) undoBtn.disabled = true;
-
         const btnCell = this.td();
-        btnCell.append(nextBtn, prevBtn, undoBtn);
+        btnCell.append(nextBtn);
         tr.append(btnCell);
         return tr;
+    }
+
+    private buildPrevButton(): HTMLButtonElement {
+        const btn = document.createElement('button');
+        btn.className = 'btn btn-secondary';
+        btn.setAttribute('accesskey', 'p');
+        btn.textContent = 'Previous';
+        btn.addEventListener('click', () => this.prev());
+        return btn;
+    }
+
+    private buildUndoButton(canUndo: boolean): HTMLButtonElement {
+        const btn = document.createElement('button');
+        btn.className = 'btn btn-secondary';
+        btn.setAttribute('accesskey', 'u');
+        btn.textContent = 'Undo';
+        btn.addEventListener('click', () => this.undo());
+        if (!canUndo) btn.disabled = true;
+        return btn;
     }
 
     private buildCandidateRows(matchItem: Item, candidates: Candidate[], mismatchColors: Record<string, string>): HTMLTableRowElement[] {


### PR DESCRIPTION
## Summary
- Previous and Undo buttons now render in a `div` below the comparison table instead of inside the System A row
- No Match button stays in the table as the action for the current item
- `buildMatchRow` no longer needs the `canUndo` parameter; two new private helpers `buildPrevButton` / `buildUndoButton` handle construction

## Test plan
- [x] New tests assert Previous and Undo buttons are NOT found inside `<table>` elements
- [x] New test asserts No Match button IS found inside `<table>`
- [x] All 112 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)