### PR TITLE
Rename BootstrapView to TableView (closes #66)

### DIFF
--- a/reconcileTableView.test.js
+++ b/reconcileTableView.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { BootstrapView } from './src/bootstrapView';
+import { TableView } from './src/tableView';
 
 const WEIGHTS = { EXACT: 100, WHITESPACE: 80, CONTAINS: 30 };
 
@@ -7,10 +7,10 @@ function makeContainer() {
     return document.createElement('div');
 }
 
-describe('BootstrapView', () => {
+describe('TableView', () => {
     describe('constructor', () => {
         it('can be constructed with a container element and weights', () => {
-            const view = new BootstrapView(makeContainer(), WEIGHTS);
+            const view = new TableView(makeContainer(), WEIGHTS);
             expect(view).toBeDefined();
         });
     });
@@ -20,7 +20,7 @@ describe('BootstrapView', () => {
 
         beforeEach(() => {
             container = makeContainer();
-            view = new BootstrapView(container, WEIGHTS);
+            view = new TableView(container, WEIGHTS);
         });
 
         const matchItem = { id: '0', name: 'Alice' };
@@ -190,7 +190,7 @@ describe('BootstrapView', () => {
 
         beforeEach(() => {
             container = makeContainer();
-            view = new BootstrapView(container, WEIGHTS);
+            view = new TableView(container, WEIGHTS);
         });
 
         const multiItem = { id: '0', name: 'Alice', city: 'NYC' };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import { SampleDataService } from './sampleDataService';
-import { BootstrapView } from './bootstrapView';
+import { TableView } from './tableView';
 import { Reconciler } from './reconciler';
 import { Scorer } from './scorer';
 import 'bootstrap/dist/css/bootstrap.min.css';
@@ -10,7 +10,7 @@ const container = document.querySelector<HTMLElement>('.reconcile')!;
 
 const service = new SampleDataService();
 const scorer  = new Scorer(WEIGHTS);
-const view    = new BootstrapView(container, WEIGHTS);
+const view    = new TableView(container, WEIGHTS);
 const reconciler = new Reconciler(service, view, scorer);
 
 reconciler.init();

--- a/src/tableView.ts
+++ b/src/tableView.ts
@@ -1,6 +1,6 @@
 import { IView, Item, Candidate, Match, ActionType, ActionEvent, Weights } from './types';
 
-export class BootstrapView implements IView {
+export class TableView implements IView {
     private readonly idProperty = 'id';
     private readonly listeners: Partial<Record<ActionType, Array<(e: ActionEvent) => void>>> = {};
     private readonly columnColors = ['#ffff00', '#add8e6', '#90ee90', '#ffb6c1', '#ffa07a', '#dda0dd'];


### PR DESCRIPTION
## Summary
- Renamed `BootstrapView` → `TableView` and `src/bootstrapView.ts` → `src/tableView.ts`
- Renamed `reconcileBootstrapView.test.js` → `reconcileTableView.test.js` with updated imports
- Updated `src/main.ts` to import and instantiate `TableView`

The class has no Bootstrap-specific logic — it renders a plain HTML table using vanilla DOM APIs. `TableView` accurately describes what it does.

## Test plan
- [x] TDD: renamed test file caused module-not-found failure (red) before `tableView.ts` existed
- [x] All 112 tests pass after the rename (green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)