### PR TITLE
fix: update README to reference TableView instead of BootstrapView

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Each field in a candidate is scored independently against the corresponding fiel
 | Contains | 30 | `Anders` ⊂ `Anderson` |
 | Transposition | 20 | `Oliver` ≈ `Oilver` (exactly one adjacent character swap) |
 
-Weights are constructor-injected into `Scorer` and `BootstrapView`, so they can be tuned without changing source code.
+Weights are constructor-injected into `Scorer` and `TableView`, so they can be tuned without changing source code.
 
 Individual columns can override any weight via the optional `ColumnWeights` map passed as a second argument to `Scorer`:
 
@@ -62,7 +62,7 @@ src/
   main.ts              — entry point; wires service, scorer, view, and reconciler
   reconciler.ts        — controller; drives the match/no-match/undo workflow
   scorer.ts            — Scorer class; scores a candidate against a match item
-  bootstrapView.ts     — BootstrapView class; renders UI with Bootstrap 5, no jQuery
+  tableView.ts         — TableView class; renders UI with Bootstrap 5, no jQuery
   sampleDataService.ts — in-browser demo service with synthetic data
   types.ts             — shared TypeScript interfaces (Weights, Item, Candidate, …)
   nicknames.json       — generated nickname equivalence groups (do not edit directly)

--- a/readme.test.js
+++ b/readme.test.js
@@ -1,0 +1,27 @@
+import { describe, it, beforeAll, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('README.md', () => {
+    let readme;
+
+    beforeAll(() => {
+        readme = readFileSync(join(__dirname, 'README.md'), 'utf8');
+    });
+
+    it('does not reference the old bootstrapView.ts filename', () => {
+        expect(readme).not.toMatch(/bootstrapView\.ts/i);
+    });
+
+    it('does not reference the old BootstrapView class name', () => {
+        expect(readme).not.toMatch(/BootstrapView/);
+    });
+
+    it('references the current tableView.ts filename in the file tree', () => {
+        expect(readme).toMatch(/tableView\.ts/);
+    });
+
+    it('references the current TableView class name', () => {
+        expect(readme).toMatch(/TableView/);
+    });
+});


### PR DESCRIPTION
Closes #82

## Summary
- Replaces stale `bootstrapView.ts` / `BootstrapView` references in the README file tree and prose with the current `tableView.ts` / `TableView` names (renamed in PR #66)
- Adds `readme.test.js` using the same file-content test pattern as `index.test.js` — four assertions guard against the old names re-appearing and confirm the new names are present

## TDD cycle
- 🔴 Red — wrote `readme.test.js` with 4 failing assertions against the stale README
- 🟢 Green — updated both stale references in `README.md`
- ✅ Refactor — full suite (116 tests) still passes

## Test plan
- [ ] `npx vitest run readme.test.js` — 4 tests pass
- [ ] `npx vitest run` — all 116 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)