### PR TITLE
fix: rename catch(status) to catch(error) in reconciler.ts

### DIFF
--- a/reconciler.test.ts
+++ b/reconciler.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('src/reconciler.ts source conventions', () => {
+    let source: string;
+
+    beforeAll(() => {
+        source = readFileSync(join(__dirname, 'src', 'reconciler.ts'), 'utf8');
+    });
+
+    it('does not use catch (status) — catch variable must be named error or err', () => {
+        expect(source).not.toMatch(/catch\s*\(\s*status\s*\)/);
+    });
+
+    it('uses catch (error) for error handling', () => {
+        expect(source).toMatch(/catch\s*\(\s*error\s*\)/);
+    });
+});

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -26,8 +26,8 @@ export class Reconciler {
             this.listA = data.a;
             this.listB = data.b;
             this.redraw();
-        } catch (status) {
-            this.view.showError(status);
+        } catch (error) {
+            this.view.showError(error);
         }
     }
 


### PR DESCRIPTION
Closes #84

## Summary
- Renames the `catch` variable in `Reconciler.init()` from `status` to `error` — `status` implies an HTTP status code rather than a generic thrown value
- Adds `reconciler.test.ts` with two source-convention assertions that guard against the old name re-appearing and confirm the correct name is present

## TDD cycle
- 🔴 Red — wrote `reconciler.test.ts` with 2 failing assertions against the stale variable name
- 🟢 Green — renamed `catch (status)` to `catch (error)` in `src/reconciler.ts`
- ✅ Refactor — full suite (118 tests) still passes

## Test plan
- [ ] `npx vitest run reconciler.test.ts` — 2 tests pass
- [ ] `npx vitest run` — all 118 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)