### PR TITLE
fix: add NICKNAME and TRANSPOSITION to WEIGHTS fixtures in test files

### DIFF
--- a/reconcile.test.js
+++ b/reconcile.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Reconciler } from './src/reconciler';
 import { Scorer } from './src/scorer';
 
-const WEIGHTS = { EXACT: 100, WHITESPACE: 80, CONTAINS: 30 };
+const WEIGHTS = { EXACT: 100, WHITESPACE: 80, NICKNAME: 60, CONTAINS: 30, TRANSPOSITION: 20 };
 
 describe('Reconciler', () => {
     let reconcile, service, view, scorer;
@@ -67,6 +67,22 @@ describe('Reconciler', () => {
                 [{ id: 'X', name: 'Anderson' }]
             );
             expect(candidates(v)[0].weights.name).toBe(30);
+        });
+
+        it('scores a nickname match at 60', async () => {
+            const { v } = await setup(
+                [{ id: '1', firstName: 'Nick' }],
+                [{ id: 'X', firstName: 'Nicholas' }]
+            );
+            expect(candidates(v)[0].weights.firstName).toBe(60);
+        });
+
+        it('scores a transposition match at 20', async () => {
+            const { v } = await setup(
+                [{ id: '1', name: 'Oliver' }],
+                [{ id: 'X', name: 'Oilver' }]
+            );
+            expect(candidates(v)[0].weights.name).toBe(20);
         });
 
         it('excludes items with no matching fields from candidates', async () => {

--- a/reconcileTableView.test.js
+++ b/reconcileTableView.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { TableView } from './src/tableView';
 
-const WEIGHTS = { EXACT: 100, WHITESPACE: 80, CONTAINS: 30 };
+const WEIGHTS = { EXACT: 100, WHITESPACE: 80, NICKNAME: 60, CONTAINS: 30, TRANSPOSITION: 20 };
 
 function makeContainer() {
     return document.createElement('div');


### PR DESCRIPTION
Closes #70.

## Summary
- `reconcile.test.js` and `reconcileTableView.test.js` both defined `WEIGHTS` with only 3 keys (`EXACT`, `WHITESPACE`, `CONTAINS`), missing `NICKNAME: 60` and `TRANSPOSITION: 20`
- With the stale fixture, `w.NICKNAME` and `w.TRANSPOSITION` were `undefined`, so the Scorer silently returned `undefined` for those match types — nickname/transposition regressions were invisible to the test suite
- Added two failing integration tests first (TDD red phase), then expanded both `WEIGHTS` constants to the full 5-key object matching production `src/main.ts`

## Test plan
- [x] Confirmed 2 new tests failed before the fix (RED)
- [x] All 120 tests pass after the fix (GREEN)
- [x] No existing tests were broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)