### PR TITLE
fix: guard against stale IDs in Reconciler.match()

### DIFF
--- a/reconcile.test.js
+++ b/reconcile.test.js
@@ -250,4 +250,20 @@ describe('Reconciler', () => {
             });
         });
     });
+
+    describe('match() — stale ID guard', () => {
+        it('does not call service.set() when aId does not match any listA item', () => {
+            reconcile.match({ a: 'STALE', b: 'A' });
+            expect(service.set).not.toHaveBeenCalled();
+        });
+
+        it('does not call service.set() when bId does not match any listB item', () => {
+            reconcile.match({ a: '5', b: 'STALE' });
+            expect(service.set).not.toHaveBeenCalled();
+        });
+
+        it('does not throw when both IDs are stale', () => {
+            expect(() => reconcile.match({ a: 'STALE_A', b: 'STALE_B' })).not.toThrow();
+        });
+    });
 });

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -57,8 +57,9 @@ export class Reconciler {
     match(event: ActionEvent): void {
         const { a: aId, b: bId } = event;
         if (!aId || !bId) return;
-        const aItem = this.listA.find(item => item[this.idProperty] === aId)!;
-        const bItem = this.listB.find(item => item[this.idProperty] === bId)!;
+        const aItem = this.listA.find(item => item[this.idProperty] === aId);
+        const bItem = this.listB.find(item => item[this.idProperty] === bId);
+        if (!aItem || !bItem) return;
         const differences = this.computeDifferences(aItem, bItem);
         this.service.set(aId, bId, this.currentUsername, differences);
         const lastMatch: Match = { a: aItem, b: bItem };


### PR DESCRIPTION
Closes #71.

## Summary
- `reconciler.ts:60-61` used non-null assertions (`!`) on `.find()` results — if a stale DOM event fired an ID that no longer existed in `listA`/`listB`, `computeDifferences` and `service.set` silently received `undefined`, corrupting state
- Replaced `!` assertions with an explicit `if (!aItem || !bItem) return` early exit
- Added 3 integration tests first (TDD red phase) covering: stale `aId`, stale `bId`, and both stale — all confirmed failing before the fix

## Test plan
- [x] 3 new tests failed before the fix (RED)
- [x] All 123 tests pass after the fix (GREEN)
- [x] No existing tests broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)