### PR TITLE
fix: remove CDN Bootstrap link from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,7 @@
 <html>
     <head>
         <title>reconcile test page</title>
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
-    </head>
+</head>
     <body>
         <div style="border: 1pt solid black; margin: 30px;">
             <div class="reconcile"></div>

--- a/index.test.js
+++ b/index.test.js
@@ -18,9 +18,19 @@ describe('index.html', () => {
         expect(html).not.toMatch(/jquery/i);
     });
 
-    it('loads Bootstrap 5.x or later', () => {
-        const match = html.match(/bootstrap[/@-](\d+)\.\d+/i);
-        expect(match).not.toBeNull();
-        expect(parseInt(match[1])).toBeGreaterThanOrEqual(5);
+    it('does not load Bootstrap from a CDN link', () => {
+        expect(html).not.toMatch(/<link[^>]+bootstrap[^>]*>/i);
+    });
+});
+
+describe('main.ts', () => {
+    let src;
+
+    beforeAll(() => {
+        src = readFileSync(join(__dirname, 'src', 'main.ts'), 'utf8');
+    });
+
+    it('imports Bootstrap via npm (not CDN)', () => {
+        expect(src).toMatch(/import\s+['"]bootstrap\//);
     });
 });


### PR DESCRIPTION
Closes #80.

## Summary
- `index.html:4` loaded Bootstrap via a CDN `<link>` tag with no SRI integrity hash, duplicating the npm import in `src/main.ts` and creating a supply-chain risk
- Removed the CDN `<link>` tag entirely — Bootstrap is now loaded exclusively through the Vite-bundled npm import in `main.ts`, which covers both dev and production
- Added a regression test to `index.test.js` that prevents the CDN link from being reintroduced
- Updated the "loads Bootstrap" assertion to verify the npm import in `main.ts` rather than `index.html`

## Test plan
- [x] 1 new test failed before the fix (RED): `does not load Bootstrap from a CDN link`
- [x] All 124 tests pass after the fix (GREEN)
- [x] No existing tests broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)