### PR TITLE
fix: handle unhandled promise rejection from reconciler.init()

### DIFF
--- a/main.test.ts
+++ b/main.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('src/main.ts source conventions', () => {
+    let source: string;
+
+    beforeAll(() => {
+        source = readFileSync(join(__dirname, 'src', 'main.ts'), 'utf8');
+    });
+
+    it('handles the promise returned by reconciler.init() with .catch()', () => {
+        expect(source).toMatch(/reconciler\.init\(\)\s*\.catch\(/);
+    });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,4 +13,4 @@ const scorer  = new Scorer(WEIGHTS);
 const view    = new TableView(container, WEIGHTS);
 const reconciler = new Reconciler(service, view, scorer);
 
-reconciler.init();
+reconciler.init().catch(err => view.showError(err));


### PR DESCRIPTION
Closes #74.

## Summary
- `src/main.ts` called `reconciler.init()` without `.catch()`, so any error thrown outside the internal `try/catch` (e.g. during `redraw()` after load) produced a silent unhandled promise rejection with no user feedback
- Added `.catch(err => view.showError(err))` so all rejection paths route to the view's error display
- Added `main.test.ts` with a source-convention test to prevent regression (new test file, following the same pattern as `reconciler.test.ts`)

## Test plan
- [x] 1 new test failed before the fix (RED): `handles the promise returned by reconciler.init() with .catch()`
- [x] All 125 tests pass after the fix (GREEN)
- [x] No existing tests broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)