### PR TITLE
fix: scope coverage collection to src/ in vite.config.ts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,9 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
     test: {
         environment: 'jsdom',
+        coverage: {
+            include: ['src/**'],
+            exclude: ['src/main.ts'],
+        },
     },
 });

--- a/vite.test.js
+++ b/vite.test.js
@@ -16,4 +16,16 @@ describe('Vite scaffolding', () => {
         const config = readFileSync(join(__dirname, 'vite.config.ts'), 'utf8');
         expect(config).toContain("environment: 'jsdom'");
     });
+
+    it('scopes coverage collection to src/', () => {
+        const { readFileSync } = require('fs');
+        const config = readFileSync(join(__dirname, 'vite.config.ts'), 'utf8');
+        expect(config).toMatch(/include\s*:\s*\[['"`]src\/\*\*['"`]\]/);
+    });
+
+    it('excludes src/main.ts from coverage collection', () => {
+        const { readFileSync } = require('fs');
+        const config = readFileSync(join(__dirname, 'vite.config.ts'), 'utf8');
+        expect(config).toMatch(/exclude\s*:.*src\/main\.ts/s);
+    });
 });


### PR DESCRIPTION
Closes #72.

## Summary
- The stale `coverage/` report measured `reconcile.js`, `reconcileBootstrapView.js`, and `reconcileTestService.js` — all deleted legacy files — with zero coverage of anything under `src/`
- Added a `coverage` block to `vite.config.ts` scoping `include` to `src/**` and excluding `src/main.ts` (composition root, not unit-testable in isolation)
- The `coverage/` directory is already gitignored so no further action needed there

## Test plan
- [x] 2 new tests failed before the fix (RED): coverage `include` and `exclude` assertions in `vite.test.js`
- [x] All 127 tests pass after the fix (GREEN)
- [x] No existing tests broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)