### PR TITLE
fix: replace globals.jest with explicit Vitest globals in eslint.config.mjs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,7 +26,16 @@ export default [
         files: ["**/*.test.js", "__mocks__/**/*.js"],
         languageOptions: {
             globals: {
-                ...globals.jest,
+                describe: 'readonly',
+                it: 'readonly',
+                test: 'readonly',
+                expect: 'readonly',
+                beforeAll: 'readonly',
+                afterAll: 'readonly',
+                beforeEach: 'readonly',
+                afterEach: 'readonly',
+                vi: 'readonly',
+                suite: 'readonly',
                 ...globals.node,
                 ...globals.browser,
             }

--- a/eslint.config.test.js
+++ b/eslint.config.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('eslint.config.mjs source conventions', () => {
+    let config;
+
+    beforeAll(() => {
+        config = readFileSync(join(__dirname, 'eslint.config.mjs'), 'utf8');
+    });
+
+    it('does not spread globals.jest into test file config', () => {
+        expect(config).not.toMatch(/globals\.jest/);
+    });
+
+    it('declares vi as a global for test files', () => {
+        expect(config).toMatch(/\bvi\b\s*:/);
+    });
+});


### PR DESCRIPTION
Closes #85.

## Summary
- `eslint.config.mjs` spread `globals.jest` into the test file config, which declared `jest`, `pit`, `fit`, and `fdescribe` as valid globals — none of which exist in Vitest — while omitting `vi` (Vitest's spy/mock utility)
- The installed `globals` package (v14) has no `vitest` key, so replaced `...globals.jest` with an explicit inline Vitest globals object: `describe`, `it`, `test`, `expect`, `beforeAll`, `afterAll`, `beforeEach`, `afterEach`, `vi`, `suite`
- Added `eslint.config.test.js` with source-convention tests to pin the fix

## Test plan
- [x] 2 new tests failed before the fix (RED): no `globals.jest` reference, `vi:` declared
- [x] All 129 tests pass after the fix (GREEN)
- [x] `npx eslint .` passes cleanly with the updated config

🤖 Generated with [Claude Code](https://claude.com/claude-code)