### PR TITLE
fix: remove unused weights parameter from TableView constructor

### DIFF
--- a/main.test.ts
+++ b/main.test.ts
@@ -12,4 +12,8 @@ describe('src/main.ts source conventions', () => {
     it('handles the promise returned by reconciler.init() with .catch()', () => {
         expect(source).toMatch(/reconciler\.init\(\)\s*\.catch\(/);
     });
+
+    it('constructs TableView without passing weights', () => {
+        expect(source).not.toMatch(/new TableView\s*\([^)]*WEIGHTS[^)]*\)/);
+    });
 });

--- a/reconcileTableView.test.js
+++ b/reconcileTableView.test.js
@@ -1,16 +1,14 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { TableView } from './src/tableView';
 
-const WEIGHTS = { EXACT: 100, WHITESPACE: 80, NICKNAME: 60, CONTAINS: 30, TRANSPOSITION: 20 };
-
 function makeContainer() {
     return document.createElement('div');
 }
 
 describe('TableView', () => {
     describe('constructor', () => {
-        it('can be constructed with a container element and weights', () => {
-            const view = new TableView(makeContainer(), WEIGHTS);
+        it('can be constructed with a container element', () => {
+            const view = new TableView(makeContainer());
             expect(view).toBeDefined();
         });
     });
@@ -20,7 +18,7 @@ describe('TableView', () => {
 
         beforeEach(() => {
             container = makeContainer();
-            view = new TableView(container, WEIGHTS);
+            view = new TableView(container);
         });
 
         const matchItem = { id: '0', name: 'Alice' };
@@ -190,7 +188,7 @@ describe('TableView', () => {
 
         beforeEach(() => {
             container = makeContainer();
-            view = new TableView(container, WEIGHTS);
+            view = new TableView(container);
         });
 
         const multiItem = { id: '0', name: 'Alice', city: 'NYC' };

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ const container = document.querySelector<HTMLElement>('.reconcile')!;
 
 const service = new SampleDataService();
 const scorer  = new Scorer(WEIGHTS);
-const view    = new TableView(container, WEIGHTS);
+const view    = new TableView(container);
 const reconciler = new Reconciler(service, view, scorer);
 
 reconciler.init().catch(err => view.showError(err));

--- a/src/tableView.ts
+++ b/src/tableView.ts
@@ -1,4 +1,4 @@
-import { IView, Item, Candidate, Match, ActionType, ActionEvent, Weights } from './types';
+import { IView, Item, Candidate, Match, ActionType, ActionEvent } from './types';
 
 export class TableView implements IView {
     private readonly idProperty = 'id';
@@ -7,7 +7,6 @@ export class TableView implements IView {
 
     constructor(
         private readonly masterDiv: HTMLElement,
-        private readonly weights: Weights,
     ) {}
 
     load(matchItem: Item, candidates: Candidate[], listA: Item[], listB: Item[], memento: Match[]): void {

--- a/tableView.test.ts
+++ b/tableView.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('src/tableView.ts source conventions', () => {
+    let source: string;
+
+    beforeAll(() => {
+        source = readFileSync(join(__dirname, 'src', 'tableView.ts'), 'utf8');
+    });
+
+    it('TableView constructor does not accept a weights parameter', () => {
+        expect(source).not.toMatch(/constructor\s*\([^)]*weights[^)]*\)/);
+    });
+});


### PR DESCRIPTION
Closes #81.

## Summary
- `TableView` accepted `private readonly weights: Weights` as a constructor argument but never referenced `this.weights` anywhere in the class body, creating a misleading API
- Removed the parameter and the `Weights` import from `src/tableView.ts`
- Updated both call sites: `src/main.ts` and `reconcileTableView.test.js`
- Dropped the now-unused `WEIGHTS` constant from `reconcileTableView.test.js`
- Added `tableView.test.ts` with a source-convention test (TDD red), and a matching assertion in `main.test.ts`

## Test plan
- [x] 2 new tests failed before the fix (RED): constructor weights param assertion in `tableView.test.ts`, and `main.test.ts` call-site assertion
- [x] All 134 tests pass after the fix (GREEN)
- [x] No existing tests broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)