### PR TITLE
fix: extract idProperty to shared ID_PROPERTY constant (#77)

### DIFF
--- a/id-property.test.ts
+++ b/id-property.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('ID_PROPERTY constant — single source of truth', () => {
+    let types: string;
+    let reconciler: string;
+    let scorer: string;
+    let tableView: string;
+
+    beforeAll(() => {
+        types      = readFileSync(join(__dirname, 'src', 'types.ts'),      'utf8');
+        reconciler = readFileSync(join(__dirname, 'src', 'reconciler.ts'), 'utf8');
+        scorer     = readFileSync(join(__dirname, 'src', 'scorer.ts'),     'utf8');
+        tableView  = readFileSync(join(__dirname, 'src', 'tableView.ts'),  'utf8');
+    });
+
+    it('types.ts exports ID_PROPERTY', () => {
+        expect(types).toMatch(/export\s+const\s+ID_PROPERTY\s*=/);
+    });
+
+    it('reconciler.ts imports ID_PROPERTY from types', () => {
+        expect(reconciler).toMatch(/ID_PROPERTY/);
+    });
+
+    it('reconciler.ts does not declare a local idProperty field', () => {
+        expect(reconciler).not.toMatch(/private\s+readonly\s+idProperty\s*=/);
+    });
+
+    it('scorer.ts imports ID_PROPERTY from types', () => {
+        expect(scorer).toMatch(/ID_PROPERTY/);
+    });
+
+    it('scorer.ts does not declare a local idProperty variable', () => {
+        expect(scorer).not.toMatch(/const\s+idProperty\s*=/);
+    });
+
+    it('tableView.ts imports ID_PROPERTY from types', () => {
+        expect(tableView).toMatch(/ID_PROPERTY/);
+    });
+
+    it('tableView.ts does not declare a local idProperty field', () => {
+        expect(tableView).not.toMatch(/private\s+readonly\s+idProperty\s*=/);
+    });
+});

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -1,4 +1,4 @@
-import { IService, IView, Item, Match, ActionEvent, Difference } from './types';
+import { IService, IView, Item, Match, ActionEvent, Difference, ID_PROPERTY } from './types';
 import { Scorer } from './scorer';
 
 export class Reconciler {
@@ -6,7 +6,6 @@ export class Reconciler {
     private listA: Item[] = [];
     private listB: Item[] = [];
     private readonly memento: Match[] = [];
-    private readonly idProperty = 'id';
 
     constructor(
         private readonly service: IService,
@@ -46,7 +45,7 @@ export class Reconciler {
     private computeDifferences(a: Item, b: Item): Difference[] {
         const differences: Difference[] = [];
         for (const field of Object.keys(a)) {
-            if (field === this.idProperty) continue;
+            if (field === ID_PROPERTY) continue;
             if (a[field] !== b[field]) {
                 differences.push({ field, aValue: a[field], bValue: b[field] });
             }
@@ -57,22 +56,22 @@ export class Reconciler {
     match(event: ActionEvent): void {
         const { a: aId, b: bId } = event;
         if (!aId || !bId) return;
-        const aItem = this.listA.find(item => item[this.idProperty] === aId);
-        const bItem = this.listB.find(item => item[this.idProperty] === bId);
+        const aItem = this.listA.find(item => item[ID_PROPERTY] === aId);
+        const bItem = this.listB.find(item => item[ID_PROPERTY] === bId);
         if (!aItem || !bItem) return;
         const differences = this.computeDifferences(aItem, bItem);
         this.service.set(aId, bId, this.currentUsername, differences);
         const lastMatch: Match = { a: aItem, b: bItem };
         this.memento.push(lastMatch);
-        this.listA = this.listA.filter(item => item[this.idProperty] !== aId);
-        this.listB = this.listB.filter(item => item[this.idProperty] !== bId);
+        this.listA = this.listA.filter(item => item[ID_PROPERTY] !== aId);
+        this.listB = this.listB.filter(item => item[ID_PROPERTY] !== bId);
         this.redraw();
     }
 
     undo(): void {
         if (this.memento.length === 0) return;
         const lastMatch = this.memento.pop()!;
-        this.service.undo(lastMatch.a[this.idProperty] as string, lastMatch.b[this.idProperty] as string);
+        this.service.undo(lastMatch.a[ID_PROPERTY] as string, lastMatch.b[ID_PROPERTY] as string);
         this.listA.push(lastMatch.a);
         this.listB.push(lastMatch.b);
         this.position = this.listA.length - 1;

--- a/src/scorer.ts
+++ b/src/scorer.ts
@@ -1,4 +1,4 @@
-import { Item, Candidate, Weights, ColumnWeights } from './types';
+import { Item, Candidate, Weights, ColumnWeights, ID_PROPERTY } from './types';
 import NICKNAME_GROUPS from './nicknames.json';
 
 const NICKNAME_MAP = new Map<string, number>();
@@ -59,14 +59,13 @@ export class Scorer {
 
     getCandidates(matchItem: Item, list: Item[]): Candidate[] {
         if (matchItem == null) return [];
-        const idProperty = 'id';
         return list.map(item => {
             const candidate: Record<string, unknown> = {};
             const weights: Record<string, number> = {};
             let matchTotal = 0;
             Object.keys(item).forEach(key => {
                 candidate[key] = item[key];
-                if (key !== idProperty) {
+                if (key !== ID_PROPERTY) {
                     weights[key] = this.getWeight(item[key], matchItem[key], key);
                     matchTotal += weights[key];
                 }

--- a/src/tableView.ts
+++ b/src/tableView.ts
@@ -1,7 +1,6 @@
-import { IView, Item, Candidate, Match, ActionType, ActionEvent } from './types';
+import { IView, Item, Candidate, Match, ActionType, ActionEvent, ID_PROPERTY } from './types';
 
 export class TableView implements IView {
-    private readonly idProperty = 'id';
     private readonly listeners: Partial<Record<ActionType, Array<(e: ActionEvent) => void>>> = {};
     private readonly columnColors = ['#ffff00', '#add8e6', '#90ee90', '#ffb6c1', '#ffa07a', '#dda0dd'];
 
@@ -76,7 +75,7 @@ export class TableView implements IView {
         const colors: Record<string, string> = {};
         let colorIdx = 0;
         Object.keys(matchItem)
-            .filter(k => k !== this.idProperty)
+            .filter(k => k !== ID_PROPERTY)
             .forEach(key => {
                 if (candidates.some(c => c[key] !== matchItem[key])) {
                     colors[key] = this.columnColors[colorIdx % this.columnColors.length];
@@ -91,7 +90,7 @@ export class TableView implements IView {
         tr.style.backgroundColor = '#000';
         tr.style.color = '#fff';
         Object.keys(matchItem).forEach(key => {
-            if (key !== this.idProperty) {
+            if (key !== ID_PROPERTY) {
                 const th = document.createElement('th');
                 th.textContent = key;
                 tr.append(th);
@@ -105,7 +104,7 @@ export class TableView implements IView {
         const tr = document.createElement('tr');
         tr.style.borderBottom = '3px solid #333';
         Object.keys(matchItem).forEach(key => {
-            if (key !== this.idProperty) {
+            if (key !== ID_PROPERTY) {
                 const cell = this.td(String(matchItem[key]));
                 if (mismatchColors[key]) cell.style.backgroundColor = mismatchColors[key];
                 tr.append(cell);
@@ -147,7 +146,7 @@ export class TableView implements IView {
         return candidates.map((item, index) => {
             const tr = document.createElement('tr');
             Object.keys(item).forEach(key => {
-                if (key !== this.idProperty && key !== 'weights') {
+                if (key !== ID_PROPERTY && key !== 'weights') {
                     const cell = this.td(String(item[key]));
                     if (mismatchColors[key] && item[key] !== matchItem[key]) {
                         cell.style.backgroundColor = mismatchColors[key];
@@ -159,8 +158,8 @@ export class TableView implements IView {
             const btn = document.createElement('button');
             btn.className = 'btn btn-success';
             if (index === 0) btn.setAttribute('accesskey', 'm');
-            btn.setAttribute('data-a', String(matchItem[this.idProperty]));
-            btn.setAttribute('data-b', String(item[this.idProperty]));
+            btn.setAttribute('data-a', String(matchItem[ID_PROPERTY]));
+            btn.setAttribute('data-b', String(item[ID_PROPERTY]));
             btn.textContent = 'Match';
             btn.addEventListener('click', (e) => this.match(e));
             const btnCell = this.td();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+export const ID_PROPERTY = 'id';
+
 export interface Weights {
     EXACT: number;
     WHITESPACE: number;


### PR DESCRIPTION
## Summary

- Exports `ID_PROPERTY = 'id'` from `src/types.ts` as the single source of truth
- Removes the independently declared `idProperty` field/variable from `reconciler.ts`, `scorer.ts`, and `tableView.ts`
- All three files now import and use the shared constant

## Test plan

- [x] New test file `id-property.test.ts` — 7 tests written red-first, verifying the constant is exported from `types.ts` and that no local `idProperty` declarations remain in the three files
- [x] Full suite: 141 tests passing

Closes #77