### PR TITLE
fix: extract 'matchTotal' to shared MATCH_TOTAL constant (#75)

### DIFF
--- a/match-total.test.ts
+++ b/match-total.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('MATCH_TOTAL constant — single source of truth', () => {
+    let types: string;
+    let scorer: string;
+    let tableView: string;
+
+    beforeAll(() => {
+        types     = readFileSync(join(__dirname, 'src', 'types.ts'),     'utf8');
+        scorer    = readFileSync(join(__dirname, 'src', 'scorer.ts'),    'utf8');
+        tableView = readFileSync(join(__dirname, 'src', 'tableView.ts'), 'utf8');
+    });
+
+    it('types.ts exports MATCH_TOTAL', () => {
+        expect(types).toMatch(/export\s+const\s+MATCH_TOTAL\s*=/);
+    });
+
+    it('scorer.ts imports MATCH_TOTAL from types', () => {
+        expect(scorer).toMatch(/MATCH_TOTAL/);
+    });
+
+    it('scorer.ts does not use the "matchTotal" bracket-access string', () => {
+        expect(scorer).not.toMatch(/\['matchTotal'\]/);
+    });
+
+    it('tableView.ts imports MATCH_TOTAL from types', () => {
+        expect(tableView).toMatch(/MATCH_TOTAL/);
+    });
+
+    it('tableView.ts does not use the "matchTotal" bracket-access string', () => {
+        expect(tableView).not.toMatch(/\['matchTotal'\]/);
+    });
+});

--- a/src/scorer.ts
+++ b/src/scorer.ts
@@ -1,4 +1,4 @@
-import { Item, Candidate, Weights, ColumnWeights, ID_PROPERTY } from './types';
+import { Item, Candidate, Weights, ColumnWeights, ID_PROPERTY, MATCH_TOTAL } from './types';
 import NICKNAME_GROUPS from './nicknames.json';
 
 const NICKNAME_MAP = new Map<string, number>();
@@ -70,11 +70,11 @@ export class Scorer {
                     matchTotal += weights[key];
                 }
             });
-            weights['matchTotal'] = matchTotal;
+            weights[MATCH_TOTAL] = matchTotal;
             candidate['weights'] = weights;
             return candidate as Candidate;
         })
-        .filter(item => item.weights['matchTotal'] > 0)
-        .sort((a, b) => b.weights['matchTotal'] - a.weights['matchTotal']);
+        .filter(item => item.weights[MATCH_TOTAL] > 0)
+        .sort((a, b) => b.weights[MATCH_TOTAL] - a.weights[MATCH_TOTAL]);
     }
 }

--- a/src/tableView.ts
+++ b/src/tableView.ts
@@ -1,4 +1,4 @@
-import { IView, Item, Candidate, Match, ActionType, ActionEvent, ID_PROPERTY } from './types';
+import { IView, Item, Candidate, Match, ActionType, ActionEvent, ID_PROPERTY, MATCH_TOTAL } from './types';
 
 export class TableView implements IView {
     private readonly listeners: Partial<Record<ActionType, Array<(e: ActionEvent) => void>>> = {};
@@ -30,7 +30,7 @@ export class TableView implements IView {
             controlBar.append(this.buildPrevButton(), this.buildUndoButton(memento.length > 0));
             this.masterDiv.append(controlBar);
 
-            if (candidates.length === 1 || candidates[0].weights['matchTotal'] > candidates[1].weights['matchTotal']) {
+            if (candidates.length === 1 || candidates[0].weights[MATCH_TOTAL] > candidates[1].weights[MATCH_TOTAL]) {
                 const matchBtn = this.masterDiv.querySelector<HTMLButtonElement>('button[data-b]');
                 matchBtn?.focus();
             }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export const ID_PROPERTY = 'id';
+export const MATCH_TOTAL = 'matchTotal';
 
 export interface Weights {
     EXACT: number;


### PR DESCRIPTION
## Summary

- Exports `MATCH_TOTAL = 'matchTotal'` from `src/types.ts` as the single source of truth
- Replaces all four `['matchTotal']` bracket-access string usages in `scorer.ts` and `tableView.ts` with `[MATCH_TOTAL]`

## Test plan

- [x] New test file `match-total.test.ts` — 5 tests written red-first, verifying the constant is exported from `types.ts` and that no raw `['matchTotal']` strings remain in either file
- [x] Full suite: 153 tests passing

Closes #75