### PR TITLE
refactor: replace inline styles in TableView with CSS class toggles

### DIFF
--- a/reconcileTableView.test.js
+++ b/reconcileTableView.test.js
@@ -114,7 +114,7 @@ describe('TableView', () => {
         it('applies a bottom border to the System A row to separate it from candidates', () => {
             view.load(matchItem, twoCandidates, [matchItem], [], []);
             const systemARow = container.querySelectorAll('tbody tr')[0];
-            expect(systemARow.style.borderBottom).not.toBe('');
+            expect(systemARow.classList.contains('rv-match-row')).toBe(true);
         });
 
         it('does not render div.row or div.col elements', () => {
@@ -296,18 +296,22 @@ describe('TableView', () => {
             expect(container.querySelectorAll('.match-contains').length).toBe(0);
         });
 
+        function mismatchClass(el) {
+            return Array.from(el.classList).find(c => /^rv-mismatch-\d$/.test(c)) ?? '';
+        }
+
         it('applies a background color to the System A cell for a mismatching column', () => {
             view.load(multiItem, candidatesCityMismatch, [multiItem], [], []);
             const systemARow = getRows()[1]; // 0=header, 1=SystemA, 2+=candidates
             const cityCell = cellByText(systemARow, 'NYC');
-            expect(cityCell.style.backgroundColor).not.toBe('');
+            expect(mismatchClass(cityCell)).not.toBe('');
         });
 
         it('does not apply background color to the System A cell for a non-mismatching column', () => {
             view.load(multiItem, candidatesCityMismatch, [multiItem], [], []);
             const systemARow = getRows()[1];
             const nameCell = cellByText(systemARow, 'Alice');
-            expect(nameCell.style.backgroundColor).toBe('');
+            expect(mismatchClass(nameCell)).toBe('');
         });
 
         it('applies the same color to non-matching System B cells in the same column', () => {
@@ -315,16 +319,16 @@ describe('TableView', () => {
             const rows = getRows();
             const systemARow = rows[1];  // 0=header, 1=SystemA, 2+=candidates
             const candidateRow = rows[2];
-            const systemACityColor = cellByText(systemARow, 'NYC').style.backgroundColor;
-            const candidateCityColor = cellByText(candidateRow, 'LA').style.backgroundColor;
-            expect(candidateCityColor).toBe(systemACityColor);
+            const systemACityClass = mismatchClass(cellByText(systemARow, 'NYC'));
+            const candidateCityClass = mismatchClass(cellByText(candidateRow, 'LA'));
+            expect(candidateCityClass).toBe(systemACityClass);
         });
 
         it('does not apply background color to matching System B cells', () => {
             view.load(multiItem, candidatesCityMismatch, [multiItem], [], []);
             const candidateRow = getRows()[2];
             const nameCell = cellByText(candidateRow, 'Alice');
-            expect(nameCell.style.backgroundColor).toBe('');
+            expect(mismatchClass(nameCell)).toBe('');
         });
 
         it('applies no background color when all columns match', () => {
@@ -333,18 +337,18 @@ describe('TableView', () => {
             const dataCells = Array.from(systemARow.querySelectorAll('td'))
                 .filter(c => c.querySelector('button') === null);
             for (const cell of dataCells) {
-                expect(cell.style.backgroundColor).toBe('');
+                expect(mismatchClass(cell)).toBe('');
             }
         });
 
         it('assigns distinct colors to different mismatching columns', () => {
             view.load(multiItem, candidatesBothMismatch, [multiItem], [], []);
             const systemARow = getRows()[1];
-            const nameColor = cellByText(systemARow, 'Alice').style.backgroundColor;
-            const cityColor = cellByText(systemARow, 'NYC').style.backgroundColor;
-            expect(nameColor).not.toBe('');
-            expect(cityColor).not.toBe('');
-            expect(nameColor).not.toBe(cityColor);
+            const nameClass = mismatchClass(cellByText(systemARow, 'Alice'));
+            const cityClass = mismatchClass(cellByText(systemARow, 'NYC'));
+            expect(nameClass).not.toBe('');
+            expect(cityClass).not.toBe('');
+            expect(nameClass).not.toBe(cityClass);
         });
     });
 });

--- a/src/tableView.css
+++ b/src/tableView.css
@@ -1,0 +1,12 @@
+.rv-table { width: 100%; }
+
+.rv-header-row { background-color: #000; color: #fff; }
+
+.rv-match-row { border-bottom: 3px solid #333; }
+
+.rv-mismatch-0 { background-color: #ffff00; }
+.rv-mismatch-1 { background-color: #add8e6; }
+.rv-mismatch-2 { background-color: #90ee90; }
+.rv-mismatch-3 { background-color: #ffb6c1; }
+.rv-mismatch-4 { background-color: #ffa07a; }
+.rv-mismatch-5 { background-color: #dda0dd; }

--- a/src/tableView.ts
+++ b/src/tableView.ts
@@ -1,8 +1,9 @@
+import './tableView.css';
 import { IView, Item, Candidate, Match, ActionType, ActionEvent, ID_PROPERTY, MATCH_TOTAL } from './types';
 
 export class TableView implements IView {
     private readonly listeners: Partial<Record<ActionType, Array<(e: ActionEvent) => void>>> = {};
-    private readonly columnColors = ['#ffff00', '#add8e6', '#90ee90', '#ffb6c1', '#ffa07a', '#dda0dd'];
+    private readonly columnClassCount = 6;
 
     constructor(
         private readonly masterDiv: HTMLElement,
@@ -11,9 +12,9 @@ export class TableView implements IView {
     load(matchItem: Item, candidates: Candidate[], listA: Item[], listB: Item[], memento: Match[]): void {
         this.masterDiv.innerHTML = '';
         if (listA.length > 0) {
-            const mismatchColors = this.getMismatchColors(matchItem, candidates);
+            const mismatchColors = this.getMismatchClasses(matchItem, candidates);
             const table = document.createElement('table');
-            table.style.width = '100%';
+            table.classList.add('rv-table');
 
             const thead = document.createElement('thead');
             thead.append(this.buildHeaderRow(matchItem));
@@ -71,24 +72,23 @@ export class TableView implements IView {
         return cell;
     }
 
-    private getMismatchColors(matchItem: Item, candidates: Candidate[]): Record<string, string> {
-        const colors: Record<string, string> = {};
-        let colorIdx = 0;
+    private getMismatchClasses(matchItem: Item, candidates: Candidate[]): Record<string, string> {
+        const classes: Record<string, string> = {};
+        let idx = 0;
         Object.keys(matchItem)
             .filter(k => k !== ID_PROPERTY)
             .forEach(key => {
                 if (candidates.some(c => c[key] !== matchItem[key])) {
-                    colors[key] = this.columnColors[colorIdx % this.columnColors.length];
-                    colorIdx++;
+                    classes[key] = `rv-mismatch-${idx % this.columnClassCount}`;
+                    idx++;
                 }
             });
-        return colors;
+        return classes;
     }
 
     private buildHeaderRow(matchItem: Item): HTMLTableRowElement {
         const tr = document.createElement('tr');
-        tr.style.backgroundColor = '#000';
-        tr.style.color = '#fff';
+        tr.classList.add('rv-header-row');
         Object.keys(matchItem).forEach(key => {
             if (key !== ID_PROPERTY) {
                 const th = document.createElement('th');
@@ -102,11 +102,11 @@ export class TableView implements IView {
 
     private buildMatchRow(matchItem: Item, mismatchColors: Record<string, string>): HTMLTableRowElement {
         const tr = document.createElement('tr');
-        tr.style.borderBottom = '3px solid #333';
+        tr.classList.add('rv-match-row');
         Object.keys(matchItem).forEach(key => {
             if (key !== ID_PROPERTY) {
                 const cell = this.td(String(matchItem[key]));
-                if (mismatchColors[key]) cell.style.backgroundColor = mismatchColors[key];
+                if (mismatchColors[key]) cell.classList.add(mismatchColors[key]);
                 tr.append(cell);
             }
         });
@@ -149,7 +149,7 @@ export class TableView implements IView {
                 if (key !== ID_PROPERTY && key !== 'weights') {
                     const cell = this.td(String(item[key]));
                     if (mismatchColors[key] && item[key] !== matchItem[key]) {
-                        cell.style.backgroundColor = mismatchColors[key];
+                        cell.classList.add(mismatchColors[key]);
                     }
                     tr.append(cell);
                 }

--- a/tableView.test.ts
+++ b/tableView.test.ts
@@ -1,6 +1,20 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
+import { TableView } from './src/tableView';
+import { ID_PROPERTY } from './src/types';
+import type { Item, Candidate } from './src/types';
+
+const matchItem: Item = { [ID_PROPERTY]: 'a1', name: 'Alice', city: 'Boston' };
+const candidates: Candidate[] = [
+    { [ID_PROPERTY]: 'b1', name: 'Alice', city: 'New York', weights: {} },
+];
+
+function render(): HTMLElement {
+    const div = document.createElement('div');
+    new TableView(div).load(matchItem, candidates, [matchItem], [], []);
+    return div;
+}
 
 describe('src/tableView.ts source conventions', () => {
     let source: string;
@@ -11,5 +25,52 @@ describe('src/tableView.ts source conventions', () => {
 
     it('TableView constructor does not accept a weights parameter', () => {
         expect(source).not.toMatch(/constructor\s*\([^)]*weights[^)]*\)/);
+    });
+
+    it('does not set table width via inline style', () => {
+        expect(source).not.toMatch(/\.style\.width\s*=/);
+    });
+
+    it('does not set header row background/color via inline style', () => {
+        expect(source).not.toMatch(/\.style\.backgroundColor\s*=\s*['"]#000/);
+        expect(source).not.toMatch(/\.style\.color\s*=\s*['"]#fff/);
+    });
+
+    it('does not set match row border via inline style', () => {
+        expect(source).not.toMatch(/\.style\.borderBottom\s*=/);
+    });
+
+    it('does not apply mismatch colors via inline style', () => {
+        expect(source).not.toMatch(/\.style\.backgroundColor\s*=\s*mismatch/);
+    });
+});
+
+describe('TableView DOM — CSS classes instead of inline styles', () => {
+    it('table element has class rv-table (not inline width)', () => {
+        const table = render().querySelector('table')!;
+        expect(table.classList.contains('rv-table')).toBe(true);
+        expect(table.style.width).toBe('');
+    });
+
+    it('header row has class rv-header-row (not inline background/color)', () => {
+        const headerRow = render().querySelector('thead tr')!;
+        expect(headerRow.classList.contains('rv-header-row')).toBe(true);
+        expect((headerRow as HTMLElement).style.backgroundColor).toBe('');
+        expect((headerRow as HTMLElement).style.color).toBe('');
+    });
+
+    it('match item row has class rv-match-row (not inline border-bottom)', () => {
+        const matchRow = render().querySelector('tbody tr')!;
+        expect(matchRow.classList.contains('rv-match-row')).toBe(true);
+        expect((matchRow as HTMLElement).style.borderBottom).toBe('');
+    });
+
+    it('mismatch cells have a rv-mismatch-N class (not inline backgroundColor)', () => {
+        const container = render();
+        // 'city' differs (Boston vs New York) — that cell should carry a mismatch class
+        const cells = Array.from(container.querySelectorAll('tbody td')) as HTMLElement[];
+        const mismatchCell = cells.find(td => /rv-mismatch-\d/.test(td.className))!;
+        expect(mismatchCell).toBeDefined();
+        expect(mismatchCell.style.backgroundColor).toBe('');
     });
 });


### PR DESCRIPTION
## Summary

- Replaces all DOM `style.*` assignments in `src/tableView.ts` with `classList.add()` calls
- Extracts visual values (`#000`, `#fff`, `3px solid #333`, six mismatch hex colours) into `src/tableView.css`
- Renames `getMismatchColors` → `getMismatchClasses` and `columnColors` array → `columnClassCount` counter — colours now live exclusively in CSS
- Updates `reconcileTableView.test.js` mismatch-colouring tests to assert CSS classes instead of inline `backgroundColor`

## Test plan

- [x] All 168 tests pass (`npm test`)
- [x] 8 new tests added in `tableView.test.ts`:
  - DOM assertions: `rv-table`, `rv-header-row`, `rv-match-row`, `rv-mismatch-N` classes present; no inline styles
  - Source-level guards: four regex checks prevent re-introduction of inline style assignments
- [x] Existing `reconcileTableView.test.js` mismatch tests updated and passing

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)