### PR TITLE
fix: delete empty __mocks__/ directory (#86)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,7 +13,7 @@ export default [
         }
     },
     {
-        files: ["**/*.test.js", "__mocks__/**/*.js"],
+        files: ["**/*.test.js"],
         languageOptions: {
             globals: {
                 describe: 'readonly',

--- a/package.test.js
+++ b/package.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 
 const pkg = JSON.parse(readFileSync(join(__dirname, 'package.json'), 'utf8'));
@@ -47,5 +47,16 @@ describe('package.json infrastructure', () => {
 
     it('test script runs vitest', () => {
         expect(pkg.scripts.test).toContain('vitest');
+    });
+});
+
+describe('project filesystem', () => {
+    it('does not contain an empty __mocks__/ directory', () => {
+        expect(existsSync(join(__dirname, '__mocks__'))).toBe(false);
+    });
+
+    it('eslint config does not reference __mocks__/', () => {
+        const eslintConfig = readFileSync(join(__dirname, 'eslint.config.mjs'), 'utf8');
+        expect(eslintConfig).not.toMatch(/__mocks__/);
     });
 });


### PR DESCRIPTION
## Summary

- Deleted the empty `__mocks__/` directory left over after the jQuery stub was removed
- Removed the stale `__mocks__/**/*.js` glob from `eslint.config.mjs`
- Added two assertions to `package.test.js` to guard against reintroduction

Closes #86

## Test plan

- [x] New test: `does not contain an empty __mocks__/ directory` — was red before deletion, green after
- [x] New test: `eslint config does not reference __mocks__/` — was red before cleanup, green after
- [x] Full suite: 170/170 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)