### PR TITLE
docs: add JSDoc to IService, IView, and Scorer public APIs (#87)

### DIFF
--- a/build-nicknames.mjs
+++ b/build-nicknames.mjs
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+/** @type {string[][]} Each inner array is an equivalence group of nickname variants (uppercase). */
 const GROUPS = [
     // ── Male ──────────────────────────────────────────────────────────────
     ['ABE', 'ABRAHAM'],

--- a/jsdoc.test.js
+++ b/jsdoc.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('JSDoc coverage', () => {
+    let types, scorer, buildNicknames;
+
+    beforeAll(() => {
+        types = readFileSync(join(__dirname, 'src/types.ts'), 'utf8');
+        scorer = readFileSync(join(__dirname, 'src/scorer.ts'), 'utf8');
+        buildNicknames = readFileSync(join(__dirname, 'build-nicknames.mjs'), 'utf8');
+    });
+
+    describe('IService', () => {
+        it('documents load()', () => {
+            expect(types).toMatch(/IService[\s\S]*?@returns[\s\S]*?load\(\)/);
+        });
+
+        it('documents set()', () => {
+            expect(types).toMatch(/IService[\s\S]*?@param[\s\S]*?set\(/);
+        });
+
+        it('documents undo()', () => {
+            expect(types).toMatch(/IService[\s\S]*?@param[\s\S]*?undo\(/);
+        });
+    });
+
+    describe('IView', () => {
+        it('documents load()', () => {
+            expect(types).toMatch(/IView[\s\S]*?@param[\s\S]*?load\(/);
+        });
+
+        it('documents showError()', () => {
+            expect(types).toMatch(/IView[\s\S]*?@param[\s\S]*?showError\(/);
+        });
+
+        it('documents onAction()', () => {
+            expect(types).toMatch(/IView[\s\S]*?@param[\s\S]*?onAction\(/);
+        });
+    });
+
+    describe('Scorer', () => {
+        it('documents getCandidates() with @param', () => {
+            expect(scorer).toMatch(/@param[\s\S]*?getCandidates\(/);
+        });
+
+        it('documents getCandidates() with @returns', () => {
+            expect(scorer).toMatch(/@returns[\s\S]*?getCandidates\(/);
+        });
+
+        it('documents getWeight() with @param', () => {
+            expect(scorer).toMatch(/@param[\s\S]*?getWeight\(/);
+        });
+
+        it('documents getWeight() with @returns', () => {
+            expect(scorer).toMatch(/@returns[\s\S]*?getWeight\(/);
+        });
+    });
+
+    describe('build-nicknames.mjs GROUPS array', () => {
+        it('documents the expected element format with @type', () => {
+            expect(buildNicknames).toMatch(/@type\s*\{string\[\]\[\]\}/);
+        });
+    });
+});

--- a/src/scorer.ts
+++ b/src/scorer.ts
@@ -10,6 +10,7 @@ export class Scorer {
         private readonly columnWeights: ColumnWeights = {},
     ) {}
 
+    /** Returns the similarity weight between two cell values. @param cell1 Value from list A. @param cell2 Value from list B. @param column Optional column name used to apply per-column weight overrides. @returns Numeric weight (0 = no match). */
     getWeight(cell1: unknown, cell2: unknown, column?: string): number {
         if (cell1 == null) return 0;
         if (cell2 == null) return 0;
@@ -57,6 +58,7 @@ export class Scorer {
         return s1.includes(s2) || s2.includes(s1);
     }
 
+    /** Scores every item in `list` against `matchItem` and returns those with a positive match total, sorted descending. @param matchItem The item from list A to score against. @param list Items from list B to evaluate. @returns Filtered, scored, and sorted candidates. */
     getCandidates(matchItem: Item, list: Item[]): Candidate[] {
         if (matchItem == null) return [];
         return list.map(item => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,13 +40,19 @@ export interface Difference {
 }
 
 export interface IService {
+    /** Fetches both datasets. @returns Object with parallel `a` and `b` item arrays. */
     load(): Promise<{ a: Item[]; b: Item[] }>;
+    /** Records a confirmed match. @param aId ID of the item from list A. @param bId ID of the item from list B. @param currentUsername Auditing user. @param differences Field-level diff to store alongside the match. */
     set(aId: string, bId: string, currentUsername: string, differences: Difference[]): void;
+    /** Removes a previously confirmed match. @param aId ID of the item from list A. @param bId ID of the item from list B. */
     undo(aId: string, bId: string): void;
 }
 
 export interface IView {
+    /** Renders the current match item together with its scored candidates. @param matchItem The item from list A currently under review. @param candidates Scored and sorted items from list B. @param listA Full list A for context. @param listB Full list B for context. @param memento Previously confirmed matches available for undo. */
     load(matchItem: Item, candidates: Candidate[], listA: Item[], listB: Item[], memento: Match[]): void;
+    /** Displays a non-fatal error to the user. @param status Raw error value (HTTP status, Error object, etc.). */
     showError(status: unknown): void;
+    /** Registers a listener for user-driven navigation or match actions. @param type The action category to listen for. @param listener Callback invoked with the full action event. */
     onAction(type: ActionType, listener: (e: ActionEvent) => void): void;
 }


### PR DESCRIPTION
## Summary

- Added `@param` / `@returns` annotations to all three `IService` methods in `src/types.ts`
- Added `@param` / `@returns` annotations to all three `IView` methods in `src/types.ts`
- Added `@param` / `@returns` to `Scorer.getWeight()` and `Scorer.getCandidates()` in `src/scorer.ts`
- Added `@type {string[][]}` to the `GROUPS` constant in `build-nicknames.mjs`
- Added `jsdoc.test.js` with 11 assertions to prevent regression

Closes #87

## Test plan

- [x] All 11 new JSDoc tests were red before edits, green after
- [x] Full suite: 181/181 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)