### PR TITLE
refactor: make columnClassCount an injectable constructor parameter (#83)

### DIFF
--- a/src/tableView.ts
+++ b/src/tableView.ts
@@ -3,10 +3,10 @@ import { IView, Item, Candidate, Match, ActionType, ActionEvent, ID_PROPERTY, MA
 
 export class TableView implements IView {
     private readonly listeners: Partial<Record<ActionType, Array<(e: ActionEvent) => void>>> = {};
-    private readonly columnClassCount = 6;
 
     constructor(
         private readonly masterDiv: HTMLElement,
+        private readonly columnClassCount = 6,
     ) {}
 
     load(matchItem: Item, candidates: Candidate[], listA: Item[], listB: Item[], memento: Match[]): void {

--- a/tableView.test.ts
+++ b/tableView.test.ts
@@ -27,6 +27,13 @@ describe('src/tableView.ts source conventions', () => {
         expect(source).not.toMatch(/constructor\s*\([^)]*weights[^)]*\)/);
     });
 
+    it('columnClassCount is a constructor parameter, not a standalone class field', () => {
+        // A standalone field ends with `= <value>;` at class body level.
+        // A constructor parameter ends with `= <value>,` or `= <value>)`.
+        expect(source).not.toMatch(/private\s+readonly\s+columnClassCount\s*=\s*\d+\s*;/);
+        expect(source).toMatch(/constructor[\s\S]*?columnClassCount\s*=/);
+    });
+
     it('does not set table width via inline style', () => {
         expect(source).not.toMatch(/\.style\.width\s*=/);
     });
@@ -42,6 +49,37 @@ describe('src/tableView.ts source conventions', () => {
 
     it('does not apply mismatch colors via inline style', () => {
         expect(source).not.toMatch(/\.style\.backgroundColor\s*=\s*mismatch/);
+    });
+});
+
+describe('TableView — injectable columnClassCount', () => {
+    const matchItemMulti: Item = { [ID_PROPERTY]: 'a1', f1: 'x', f2: 'x', f3: 'x' };
+    const candidatesMulti: Candidate[] = [
+        { [ID_PROPERTY]: 'b1', f1: 'A', f2: 'B', f3: 'C', weights: {} },
+    ];
+
+    function renderWith(columnClassCount: number): HTMLElement {
+        const div = document.createElement('div');
+        new TableView(div, columnClassCount).load(matchItemMulti, candidatesMulti, [matchItemMulti], [], []);
+        return div;
+    }
+
+    it('uses the default of 6 CSS classes when no count is passed', () => {
+        const div = document.createElement('div');
+        new TableView(div).load(matchItem, candidates, [matchItem], [], []);
+        const cells = Array.from(div.querySelectorAll('tbody td')) as HTMLElement[];
+        const classes = cells.flatMap(td => Array.from(td.classList)).filter(c => /rv-mismatch-\d/.test(c));
+        expect(classes.every(c => parseInt(c.replace('rv-mismatch-', '')) < 6)).toBe(true);
+    });
+
+    it('cycles mismatch classes within a custom columnClassCount of 2', () => {
+        const div = renderWith(2);
+        const cells = Array.from(div.querySelectorAll('tbody td')) as HTMLElement[];
+        const indices = cells
+            .flatMap(td => Array.from(td.classList))
+            .filter(c => /rv-mismatch-\d/.test(c))
+            .map(c => parseInt(c.replace('rv-mismatch-', '')));
+        expect(indices.every(i => i < 2)).toBe(true);
     });
 });
 


### PR DESCRIPTION
## Summary

The hex color array was already moved to CSS in PR #103. The remaining hardcoded piece was `private readonly columnClassCount = 6` — a private class field that couldn't be varied without editing `TableView` internals.

- Promoted `columnClassCount` to an optional constructor parameter with a default of `6`, keeping all existing callers unchanged
- Added a source-level assertion confirming it lives in the constructor, not as a standalone field
- Added two behavioural tests: default cycles within 0–5, and a custom value of `2` keeps indices within 0–1

Closes #83

## Test plan

- [x] 2 new behavioural tests were red before the change, green after
- [x] 1 new source assertion was red before the change, green after
- [x] Full suite: 184/184 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)